### PR TITLE
feat: removed unused type from cloud model

### DIFF
--- a/budapp/model_ops/services.py
+++ b/budapp/model_ops/services.py
@@ -451,7 +451,6 @@ class CloudModelWorkflowService(SessionMixin):
                 huggingface_url=db_cloud_model.huggingface_url,
                 website_url=db_cloud_model.website_url,
                 modality=db_cloud_model.modality,
-                type=db_cloud_model.type,
                 source=db_cloud_model.source,
                 provider_type=provider_type,
                 uri=db_cloud_model.uri,


### PR DESCRIPTION
### Title: Bug Fix: Remove `type` Field from Cloud Model Creation Schema

#### Linked Issues

- Closes https://github.com/BudEcosystem/bud-serve-app/issues/16

#### Description

This PR removes the `type` field from the Cloud model creation schema, as it is no longer required. This change ensures that model creation is streamlined and avoids any unnecessary fields that may cause confusion or validation issues.

#### Methodology/Tasks Implemented

- Removed `type` field from the Cloud model creation schema.
- Updated schema documentation and validation rules to exclude `type`.

#### Testing

- Verified that Cloud model creation works as expected without the `type` field.
- Checked for any validation issues or errors during model creation.

#### Estimated Time

- Approximately 30 minutes.

#### Screenshots/Logs

<img width="1390" alt="image" src="https://github.com/user-attachments/assets/4761bc0c-3174-450a-8599-4e80d02743f4">

#### Additional Notes

- Updated API documentation to reflect the removal of `type` from the schema.