### PR TITLE
fix: UUID Parsing Error for model_id Path Parameter

### DIFF
--- a/budapp/model_ops/model_routes.py
+++ b/budapp/model_ops/model_routes.py
@@ -370,46 +370,6 @@ async def list_cloud_model_recommended_tags(
 
 
 @model_router.get(
-    "/{model_id}",
-    responses={
-        status.HTTP_500_INTERNAL_SERVER_ERROR: {
-            "model": ErrorResponse,
-            "description": "Service is unavailable due to server error",
-        },
-        status.HTTP_400_BAD_REQUEST: {
-            "model": ErrorResponse,
-            "description": "Invalid request parameters",
-        },
-        status.HTTP_200_OK: {
-            "model": ModelDetailResponse,
-            "description": "Successfully retrieved model details",
-        },
-    },
-    description="Retrieve details of a model by ID",
-)
-async def get_model_details(
-    current_user: Annotated[User, Depends(get_current_active_user)],
-    session: Annotated[Session, Depends(get_session)],
-    model_id: UUID,
-) -> Union[ModelDetailResponse, ErrorResponse]:
-    """Retrieve details of a model by its ID."""
-    try:
-        model_details = await ModelService(session).get_model_details(model_id)        
-    except ClientException as e:
-        logger.exception(f"Failed to get model details: {e}")
-        return ErrorResponse(code=status.HTTP_400_BAD_REQUEST, message=e.message).to_http_response()
-    except Exception as e:
-        logger.exception(f"Failed to get model details: {e}")
-        return ErrorResponse(
-            code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            message="Failed to retrieve model details",
-        ).to_http_response()
-    
-    return ModelDetailResponse(**model_details, message="model details fetched successfully", code=status.HTTP_200_OK, object="ModelDetailResponse")
-
-
-
-@model_router.get(
     "/tags",
     responses={
         status.HTTP_500_INTERNAL_SERVER_ERROR: {
@@ -453,3 +413,41 @@ async def search_tags_by_name(
         object="tags.search",
         code=status.HTTP_200_OK,
     ).to_http_response()
+
+@model_router.get(
+    "/{model_id}",
+    responses={
+        status.HTTP_500_INTERNAL_SERVER_ERROR: {
+            "model": ErrorResponse,
+            "description": "Service is unavailable due to server error",
+        },
+        status.HTTP_400_BAD_REQUEST: {
+            "model": ErrorResponse,
+            "description": "Invalid request parameters",
+        },
+        status.HTTP_200_OK: {
+            "model": ModelDetailResponse,
+            "description": "Successfully retrieved model details",
+        },
+    },
+    description="Retrieve details of a model by ID",
+)
+async def get_model_details(
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    session: Annotated[Session, Depends(get_session)],
+    model_id: UUID,
+) -> Union[ModelDetailResponse, ErrorResponse]:
+    """Retrieve details of a model by its ID."""
+    try:
+        model_details = await ModelService(session).get_model_details(model_id)        
+    except ClientException as e:
+        logger.exception(f"Failed to get model details: {e}")
+        return ErrorResponse(code=status.HTTP_400_BAD_REQUEST, message=e.message).to_http_response()
+    except Exception as e:
+        logger.exception(f"Failed to get model details: {e}")
+        return ErrorResponse(
+            code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            message="Failed to retrieve model details",
+        ).to_http_response()
+    
+    return ModelDetailResponse(**model_details, message="model details fetched successfully", code=status.HTTP_200_OK, object="ModelDetailResponse")


### PR DESCRIPTION
### Title: fix: UUID Parsing Error for model_id Path Parameter
#### Linked Issues

- Closes Bug: Fix UUID Parsing Error for model_id in Tags API Endpoint

#### Description

This PR resolves an issue in the Tags API where an invalid UUID error was thrown due to an improper placement of the endpoint handling model_id as a path parameter. Specifically, when non-UUID values (e.g., tags) were passed in the model_id path, an error would occur with the following message:

`{
  "detail": [
    {
      "type": "uuid_parsing",
      "loc": ["path", "model_id"],
      "msg": "Input should be a valid UUID, invalid character: expected an optional prefix of `urn:uuid:` followed by [0-9a-fA-F-], found `t` at 1",
      "input": "tags",
      "ctx": {
        "error": "invalid character: expected an optional prefix of `urn:uuid:` followed by [0-9a-fA-F-], found `t` at 1"
      }
    }
  ]
}
`

#### Methodology/Tasks Implemented

- Moved the endpoint handling model_id as a path parameter further down to avoid conflicts with non-UUID path inputs.

#### Estimated Time

- Approximately 3hrs.

#### screenshots

listing all tags:

![image](https://github.com/user-attachments/assets/d70bd511-240c-4677-bd9a-120bbee3c1c5)

searching tags:

![image](https://github.com/user-attachments/assets/5dbba88a-18b1-4dbb-80c4-3a312de0ea99)

![image](https://github.com/user-attachments/assets/08128a4b-8245-4528-9b44-c53bc29d05b1)
