### PR TITLE
Feature/get authors

### DIFF
--- a/budapp/model_ops/model_routes.py
+++ b/budapp/model_ops/model_routes.py
@@ -580,8 +580,6 @@ async def list_all_model_authors(
     session: Annotated[Session, Depends(get_session)],
     filters: Annotated[ModelAuthorFilter, Depends()],
     current_user: User = Depends(get_current_active_user),
-    tags: List[str] = Query(default_factory=list),
-    tasks: List[str] = Query(default_factory=list),
     search: bool = False,
     page: int = Query(1, ge=1),
     limit: int = Query(10, ge=0),
@@ -592,10 +590,6 @@ async def list_all_model_authors(
     offset = (page - 1) * limit
 
     filters_dict = filters.model_dump(exclude_none=True)
-    if tags:
-        filters_dict["tags"] = tags
-    if tasks:
-        filters_dict["tasks"] = tasks
 
     try:
         db_authors, count = await ModelService(session).list_all_model_authors(

--- a/budapp/model_ops/schemas.py
+++ b/budapp/model_ops/schemas.py
@@ -427,14 +427,4 @@ class ModelAuthorResponse(PaginatedSuccessResponse):
 class ModelAuthorFilter(BaseModel):
     """Filter schema for model authors."""
 
-    model_config = ConfigDict(protected_namespaces=())
-
-    source: CredentialTypeEnum | None = None
-    modality: ModalityEnum | None = None
-    model_size: int | None = None
     author: str | None = None
-
-    @field_validator("source")
-    def change_to_string(cls, v: CredentialTypeEnum | None) -> str | None:
-        """Change the source to a string."""
-        return v.value if v else None

--- a/budapp/model_ops/services.py
+++ b/budapp/model_ops/services.py
@@ -789,4 +789,11 @@ class ModelService(SessionMixin):
         search: bool = False,
     ) -> Tuple[List[str], int]:
         """Search author by name with pagination support."""
-        return await ModelDataManager(self.session).list_all_model_authors(offset, limit, filters, order_by, search)
+
+        filters["is_active"] = True
+        db_models, count = await ModelDataManager(self.session).list_all_model_authors(
+            offset, limit, filters, order_by, search
+        )
+        db_authors = [model.author for model in db_models]
+
+        return db_authors, count


### PR DESCRIPTION
### Title:feat: Implemented Get Authors API with Pagination

#### Linked Issues

- Closes issue : https://github.com/BudEcosystem/bud-serve/issues/1015

#### Description

This PR introduces a new API endpoint to retrieve a list of authors with pagination support. The feature allows users to:

-Search for authors by name (case-insensitive).
-Fetch all authors if no search value is provided.
-Apply pagination using page and limit query parameters.

#### Methodology/Tasks Implemented

- Added GET /models/authors/search endpoint.
- Updated the router and ModelDataManager to support:
      1. Searching authors by name (optional).
      2. Pagination with page and limit query parameters.

#### Estimated Time

- Approximately 1hr.

####screenshots/logs

![image](https://github.com/user-attachments/assets/c77f294b-a099-4a22-b304-8f0fd4efea30)