### PR TITLE
fix(tags and tasks): updated query to only consider name while handin…

### DIFF
--- a/budapp/model_ops/crud.py
+++ b/budapp/model_ops/crud.py
@@ -128,7 +128,7 @@ class ModelDataManager(DataManagerUtils):
             .where(func.jsonb_extract_path_text(tags_subquery.c.tag, "color").is_not(None))  # Valid colors
         ).subquery()
 
-        # Apply DISTINCT ON to get unique tags by name, selecting the first color
+        # Apply DISTINCT to get unique tags by name, selecting the first color
         distinct_on_name_query = (
             select(
                 distinct_tags_query.c.name,
@@ -194,7 +194,7 @@ class ModelDataManager(DataManagerUtils):
             .where(func.jsonb_extract_path_text(tasks_subquery.c.task, "color").is_not(None))  # Valid colors
         ).subquery()
 
-        # Apply DISTINCT ON to get unique tasks by name, selecting the first color
+        # Apply DISTINCT to get unique tasks by name, selecting the first color
         distinct_on_name_query = (
             select(
                 distinct_tasks_query.c.name,


### PR DESCRIPTION
### Title:  Fix: updated query to only consider name while handing duplicate records

#### Description

This PR addresses issues in the Tags and Tasks APIs to ensure proper handling of distinct values. 

#### Methodology/Tags Implemented

Updated both APIs to handle duplicate names efficiently.
#### Estimated Time

- Approximately 1hr.

####screenshots/logs

![image](https://github.com/user-attachments/assets/8aecdb05-545a-4960-95d8-66aedbe6adbf)


![image](https://github.com/user-attachments/assets/e4c620a5-a30c-49cf-b8c4-a5c6e1a27879)

![image](https://github.com/user-attachments/assets/601a84e7-8952-4ad2-949d-8fbc1a4b3425)