### PR TITLE
feat: added delete cluster subscriber

### DIFF
--- a/budapp/commons/constants.py
+++ b/budapp/commons/constants.py
@@ -445,6 +445,7 @@ class PayloadType(str, Enum):
     DEPLOYMENT_RECOMMENDATION = "deployment_recommendation"
     DEPLOY_MODEL = "deploy_model"
     REGISTER_CLUSTER = "register_cluster"
+    DELETE_CLUSTER = "delete_cluster"
     PERFORM_MODEL_EXTRACTION = "perform_model_extraction"
     PERFORM_MODEL_SECURITY_SCAN = "perform_model_security_scan"
 

--- a/budapp/core/services.py
+++ b/budapp/core/services.py
@@ -125,6 +125,21 @@ class NotificationService(SessionMixin):
         ):
             await LocalModelWorkflowService(self.session).create_model_from_notification_event(payload)
 
+    async def update_delete_cluster_events(self, payload: NotificationPayload) -> None:
+        """Update the delete cluster events for a workflow step.
+
+        Args:
+            payload: The payload to update the step with.
+
+        Returns:
+            None
+        """
+        await self._update_workflow_step_events(BudServeWorkflowStepEventName.DELETE_CLUSTER_EVENTS.value, payload)
+
+        # Create cluster in database if node info fetched successfully
+        if payload.content.status == "COMPLETED" and payload.content.title == "Cluster deleted successfully":
+            await ClusterService(self.session).delete_cluster_from_notification_event(payload)
+
     async def update_model_security_scan_events(self, payload: NotificationPayload) -> None:
         """Update the model security scan events for a workflow step.
 
@@ -313,6 +328,7 @@ class SubscriberHandler:
             PayloadType.REGISTER_CLUSTER: self._handle_register_cluster,
             PayloadType.PERFORM_MODEL_EXTRACTION: self._handle_perform_model_extraction,
             PayloadType.PERFORM_MODEL_SECURITY_SCAN: self._handle_perform_model_security_scan,
+            PayloadType.DELETE_CLUSTER: self._handle_delete_cluster,
         }
 
         handler = handlers.get(payload.type)
@@ -362,6 +378,14 @@ class SubscriberHandler:
         return NotificationResponse(
             object="notification",
             message="Updated model security scan event in workflow step",
+        ).to_http_response()
+
+    async def _handle_delete_cluster(self, payload: NotificationPayload) -> NotificationResponse:
+        """Handle the delete cluster event."""
+        await NotificationService(self.session).update_delete_cluster_events(payload)
+        return NotificationResponse(
+            object="notification",
+            message="Updated delete cluster event in workflow step",
         ).to_http_response()
 
 


### PR DESCRIPTION
### Title: Feature: Add Delete Cluster Workflow Subscriber

#### Description

This PR introduces a subscriber for handling the delete cluster workflow, ensuring proper event-driven execution and improving the reliability of cluster deletion processes.

#### Methodology/Tasks Implemented

- Added a subscriber to manage events in the delete cluster workflow.

#### Estimated Time

- Approximately 1 hours.

#### Screenshots/Logs

<img width="1156" alt="image" src="https://github.com/user-attachments/assets/12b17283-0227-4dc2-823d-1f5d4394e807" />