### PR TITLE
Add Endpoint Count to Cluster Listing API

### DIFF
--- a/budapp/cluster_ops/crud.py
+++ b/budapp/cluster_ops/crud.py
@@ -25,7 +25,8 @@ from sqlalchemy import and_, desc, func, or_, select
 from sqlalchemy.orm import selectinload
 
 from budapp.cluster_ops.models import Cluster
-from ..commons.constants import ClusterStatusEnum
+from ..endpoint_ops.models import Endpoint
+from ..commons.constants import ClusterStatusEnum, EndpointStatusEnum
 
 logger = logging.get_logger(__name__)
 
@@ -45,13 +46,48 @@ class ClusterDataManager(DataManagerUtils):
 
         await self.validate_fields(Cluster, filters)
 
+        # Subquery to count endpoints per cluster
+        endpoint_count_subquery = (
+            select(
+                Endpoint.cluster_id,
+                func.count(Endpoint.id.distinct()).label("endpoint_count"),
+            )
+            .where(Endpoint.status != EndpointStatusEnum.DELETED)
+            .group_by(Endpoint.cluster_id)
+            .alias("endpoint_count_subquery")
+        )
+
         # Generate statements based on search or filters
         if search:
             search_conditions = await self.generate_search_stmt(Cluster, filters)
-            stmt = select(Cluster).options(selectinload(Cluster.endpoints)).filter(and_(*search_conditions))
+            stmt = (
+                select(
+                    Cluster,
+                    func.coalesce(endpoint_count_subquery.c.endpoint_count, 0).label("endpoint_count"),
+                )
+                .filter(and_(*search_conditions))
+                .select_from(Cluster)
+                .join(
+                    endpoint_count_subquery,
+                    Cluster.id == endpoint_count_subquery.c.cluster_id,
+                    isouter=True,
+                )
+            )
             count_stmt = select(func.count()).select_from(Cluster).filter(and_(*search_conditions))
         else:
-            stmt = select(Cluster).options(selectinload(Cluster.endpoints)).filter_by(**filters)
+            stmt = (
+                select(
+                    Cluster,
+                    func.coalesce(endpoint_count_subquery.c.endpoint_count, 0).label("endpoint_count"),
+                )
+                .filter_by(**filters)
+                .select_from(Cluster)
+                .join(
+                    endpoint_count_subquery,
+                    Cluster.id == endpoint_count_subquery.c.cluster_id,
+                    isouter=True,
+                )
+            )
             count_stmt = select(func.count()).select_from(Cluster).filter_by(**filters)
 
         # Exclude deleted clusters
@@ -69,6 +105,6 @@ class ClusterDataManager(DataManagerUtils):
             sort_conditions = await self.generate_sorting_stmt(Cluster, order_by)
             stmt = stmt.order_by(*sort_conditions)
 
-        result = self.scalars_all(stmt)
+        result = self.execute_all(stmt)
 
         return result, count

--- a/budapp/cluster_ops/schemas.py
+++ b/budapp/cluster_ops/schemas.py
@@ -103,7 +103,8 @@ class ClusterResponse(BaseModel):
         return self.cpu_available_workers + self.gpu_available_workers + self.hpu_available_workers
 
 
-class ClusterPaginatedResponse(ClusterResponse):
+class ClusterPaginatedResponse(BaseModel):
+    cluster: ClusterResponse
     endpoint_count: int
 
 

--- a/budapp/cluster_ops/services.py
+++ b/budapp/cluster_ops/services.py
@@ -80,35 +80,14 @@ class ClusterService(SessionMixin):
         search: bool = False,
     ) -> Tuple[List[ClusterPaginatedResponse], int]:
         """Get all active clusters."""
-        clusters, count = await ClusterDataManager(self.session).get_all_clusters(
+        result, count = await ClusterDataManager(self.session).get_all_clusters(
             offset, limit, filters, order_by, search
         )
-        # Add dummy data and additional fields
-        updated_clusters = []
-        for cluster in clusters:
-            updated_cluster = ClusterPaginatedResponse(
-                id=cluster.id,
-                cluster_id=cluster.cluster_id,
-                name=cluster.name,
-                icon=cluster.icon,
-                ingress_url=cluster.ingress_url,
-                created_at=cluster.created_at,
-                modified_at=cluster.modified_at,
-                endpoint_count=len(cluster.endpoints),
-                status=cluster.status,
-                gpu_count=cluster.gpu_count,
-                cpu_count=cluster.cpu_count,
-                hpu_count=cluster.hpu_count,
-                cpu_total_workers=cluster.cpu_total_workers,
-                cpu_available_workers=cluster.cpu_available_workers,
-                gpu_total_workers=cluster.gpu_total_workers,
-                gpu_available_workers=cluster.gpu_available_workers,
-                hpu_total_workers=cluster.hpu_total_workers,
-                hpu_available_workers=cluster.hpu_available_workers,
-            )
-            updated_clusters.append(updated_cluster)
-
-        return updated_clusters, count
+        cluster_list = []
+        for db_result in result:
+            db_cluster, endpoints_count = db_result
+            cluster_list.append(ClusterPaginatedResponse(cluster=db_cluster, endpoint_count=endpoints_count))
+        return cluster_list, count
 
     async def create_cluster_workflow(
         self,


### PR DESCRIPTION
### Title: Feature: Add Endpoint Count to Cluster Listing API

closes : https://github.com/BudEcosystem/bud-serve/issues/1494

#### Description

This PR adds an endpoint count to the response of the cluster listing API. It provides the total number of endpoints associated with each cluster, allowing users to easily retrieve and monitor the number of endpoints for a given cluster.

#### Methodology/Tasks Implemented

- Modified the cluster listing API to include an endpoint count for each cluster.
- The count reflects the number of related endpoints for each cluster.
- Updated the API response format to include the `endpoint_count` field alongside other cluster details.

#### Estimated Time

- Approximately 1 hour.

#### Screenshots/Logs

![image](https://github.com/user-attachments/assets/7f61020a-6e22-4b20-af16-81b28092d0b6)
