### PR TITLE
refactor: removed other from model template

### DIFF
--- a/budapp/initializers/data/template_seeder.json
+++ b/budapp/initializers/data/template_seeder.json
@@ -97,16 +97,5 @@
       "ttft": [4000, 5000],
       "e2e_latency": [40, 90],
       "per_session_tokens_per_sec": [5, 25]
-    },
-    {
-      "name": "Other",
-      "description": "Custom template for unique use cases.",
-      "icon": "icons/template/other.png",
-      "template_type": "other",
-      "avg_context_length": 1000,
-      "avg_sequence_length": 300,
-      "ttft": [4000, 5000],
-      "e2e_latency": [40, 90],
-      "per_session_tokens_per_sec": [5, 25]
     }
   ]


### PR DESCRIPTION
### Title: Feature: Remove 'Other' from Model Template

#### Description

This PR updates the model template by removing the 'Other' option to streamline the model selection process and ensure consistent data.

#### Methodology/Tasks Implemented

- Removed the 'Other' option from the model template configuration.

#### Estimated Time

- Approximately 0.5 hours.