### PR TITLE
fix: notification updated

### DIFF
--- a/budapp/cluster_ops/services.py
+++ b/budapp/cluster_ops/services.py
@@ -879,7 +879,7 @@ class ClusterService(SessionMixin):
         logger.debug(f"Updated cluster count in workflow progress: {db_workflow.id}")
 
         if db_active_clusters_count == 0:
-            message = "Found 0 Clusters"
+            message = "Clusters Not Found"
         else:
             message = f"Found Top {db_active_clusters_count} Clusters"
 


### PR DESCRIPTION
### Title: Update: Notification for Cluster Not Found

#### Linked Issues

- Closes https://github.com/BudEcosystem/bud-serve/issues/1750

#### Description

This PR updates the notification message displayed when no clusters are found. The message now explicitly states "Clusters not found" for improved clarity and user understanding.

#### Methodology/Tasks Implemented

- Updated notification text from "Found 0 clusters" to "Clusters not found."

#### Estimated Time

- Approximately 0.5 hours.