### PR TITLE
feat: added project, model id and queuing time

### DIFF
--- a/budapp/metric_ops/services.py
+++ b/budapp/metric_ops/services.py
@@ -70,6 +70,7 @@ class MetricService(SessionMixin):
             message="Successfully fetched request count analytics",
             overall_metrics=bud_metric_response["overall_metrics"],
             concurrency_metrics=bud_metric_response["concurrency_metrics"],
+            queuing_time_metrics=bud_metric_response["queuing_time_metrics"],
         )
 
     async def get_request_performance_analytics(


### PR DESCRIPTION
### Title: Feature: Add Project ID, Model ID in Metric APIs and Queuing Time in Request

#### Description

This PR enhances the metric APIs by adding support for `project_id` and `model_id`, enabling more detailed metric tracking. Additionally, queuing time has been included in the request metrics to provide deeper insights into request processing times.

#### Methodology/Tasks Implemented

- Added `project_id` and `model_id` parameters to metric APIs.
- Included queuing time in request metrics.

#### Testing

- Verified metric API responses include `project_id` and `model_id` where applicable.
- Tested queuing time calculation and integration with request metrics.

#### Estimated Time

- Approximately 1 hours.

#### Screenshots/Logs

<img width="1381" alt="image" src="https://github.com/user-attachments/assets/0823f7f5-f36b-44ba-b5e6-a313758e5e3b" />