### PR TITLE
refactor: model scan formatting

### DIFF
--- a/budapp/model_ops/services.py
+++ b/budapp/model_ops/services.py
@@ -1699,10 +1699,11 @@ class LocalModelWorkflowService(SessionMixin):
         for model_issue in model_issues:
             severity = model_issue["severity"].lower()
 
+            # NOTE: changed this formatting to budmodel
             # Clean up the source path by removing local_path prefix
-            source = model_issue["source"]
-            if source.startswith(local_path):
-                source = source[len(local_path) :].lstrip("/")
+            # source = model_issue["source"]
+            # if source.startswith(local_path):
+            #     source = source[len(local_path) :].lstrip("/")
 
             # Group issues by severity
             if severity not in grouped_issues:
@@ -1712,7 +1713,7 @@ class LocalModelWorkflowService(SessionMixin):
                     title=model_issue["title"],
                     severity=severity,
                     description=model_issue["description"],
-                    source=source,
+                    source=model_issue["source"],
                 ).model_dump()
             )
 


### PR DESCRIPTION
### Title: Feature: Update Model Scan Result Formatting to Use BudModel

#### Description

This PR updates the formatting of model scan results to align with the `budmodel` standard instead of `budapp`. This change improves consistency across the application and ensures compatibility with the new model processing workflows.

#### Methodology/Tasks Implemented

- Updated model scan result formatting logic to use `budmodel`.

#### Estimated Time

- Approximately 0.5 hours.