### PR TITLE
feat: added cluster resources in cluster update

### DIFF
--- a/budapp/cluster_ops/services.py
+++ b/budapp/cluster_ops/services.py
@@ -615,9 +615,14 @@ class ClusterService(SessionMixin):
         # Update data
         update_data = {"status": payload.content.result["status"]}
 
-        # Get cluster resources from event
-        cluster_resources = await self._calculate_cluster_resources(payload.content.result["node_info"])
-        update_data.update(cluster_resources.model_dump(exclude_unset=True, exclude_none=True))
+        if "node_info" in payload.content.result:
+            if (
+                "nodes" in payload.content.result["node_info"]
+                and len(payload.content.result["node_info"]["nodes"]) > 0
+            ):
+                cluster_resources = await self._calculate_cluster_resources(payload.content.result["node_info"])
+                update_data.update(cluster_resources.model_dump(exclude_unset=True, exclude_none=True))
+                logger.debug(f"Cluster resources updated: {update_data}")
 
         # Update cluster status
         db_cluster = await ClusterDataManager(self.session).update_by_fields(db_cluster, update_data)


### PR DESCRIPTION
### Title: Feature: Add Node Info in Cluster Update Events

#### Linked Issues

- Closes https://github.com/BudEcosystem/bud-serve/issues/1775

#### Description

This PR enhances the cluster update events by including detailed node information. This change aims to provide better visibility into cluster updates and improves event logging for diagnostic purposes.

#### Methodology/Tasks Implemented

- Updated cluster update event logic to include node information.

#### Screenshots
<img width="1234" alt="image" src="https://github.com/user-attachments/assets/07dafff7-ae50-477b-917b-23ffa88ce5b9" />

#### Estimated Time

- Approximately 1 hours.