### PR TITLE
Refactor/add worker workflow

### DIFF
--- a/budapp/commons/constants.py
+++ b/budapp/commons/constants.py
@@ -466,6 +466,7 @@ class PayloadType(str, Enum):
     CLUSTER_STATUS_UPDATE = "cluster-status-update"
     DEPLOYMENT_STATUS_UPDATE = "deployment-status-update"
     DELETE_WORKER = "delete_worker"
+    ADD_WORKER = "add_worker"
 
 
 class BudServeWorkflowStepEventName(str, Enum):


### PR DESCRIPTION
### Title: Feature: Integrate Add Worker with BudCluster

#### Linked Issues

- Closes https://github.com/BudEcosystem/bud-serve/issues/1899

#### Description

This PR integrates the functionality to add a worker with BudCluster, enhancing the deployment capabilities and ensuring seamless worker management within the cluster.

#### Methodology/Tasks Implemented

- Integrated `add_worker` functionality with BudCluster

<img width="1157" alt="image" src="https://github.com/user-attachments/assets/010354b7-8d92-4a81-bee9-82ca09ea3980" />