### PR TITLE
fix: total replicas updated

### DIFF
--- a/budapp/endpoint_ops/services.py
+++ b/budapp/endpoint_ops/services.py
@@ -1172,9 +1172,13 @@ class EndpointService(SessionMixin):
         additional_concurrency = payload.content.result.get("result", {}).get("concurrency", 0)
         deployment_config["concurrent_requests"] = existing_concurrency + additional_concurrency
 
+        # Get total replicas
+        total_replicas = payload.content.result["deployment_status"]["replicas"]["total"]
+        logger.debug(f"Total replicas: {total_replicas}")
+
         self.session.refresh(db_endpoint)
         db_endpoint = await EndpointDataManager(self.session).update_by_fields(
-            db_endpoint, {"deployment_config": deployment_config}
+            db_endpoint, {"deployment_config": deployment_config, "total_replicas": total_replicas}
         )
         logger.debug(f"Updated deployment config: {deployment_config}")
 


### PR DESCRIPTION
### Title: Feature: Update Total Replica After Adding Worker to Endpoint

#### Linked Issues

- Closes https://github.com/BudEcosystem/bud-serve/issues/1899

#### Description

This PR updates the total replica count after successfully adding a worker to an endpoint, ensuring accurate representation of the deployment state.

#### Methodology/Tasks Implemented

- Adjusted the logic to update the total replica count upon successful worker addition.

#### Estimated Time

- Approximately 0.5 hours.