### PR TITLE
feat: added project info in add worker response

### DIFF
--- a/budapp/endpoint_ops/services.py
+++ b/budapp/endpoint_ops/services.py
@@ -815,6 +815,7 @@ class EndpointService(SessionMixin):
         )
 
         # Validate endpoint id
+        project_id = None
         if endpoint_id:
             db_endpoint = await EndpointDataManager(self.session).retrieve_by_fields(
                 EndpointModel, {"id": endpoint_id}, exclude_fields={"status": EndpointStatusEnum.DELETED}
@@ -838,11 +839,19 @@ class EndpointService(SessionMixin):
                 {"title": db_endpoint.name, "icon": model_icon, "tag": db_endpoint.project.name},
             )
 
+            # Assign project_id
+            project_id = db_endpoint.project_id
+
         # Prepare workflow step data
         workflow_step_data = AddWorkerWorkflowStepData(
             endpoint_id=endpoint_id,
             additional_concurrency=additional_concurrency,
         ).model_dump(exclude_none=True, exclude_unset=True, mode="json")
+
+        # NOTE: If endpoint_id is provided, then need to add project_id to workflow step data
+        # Required for frontend integration
+        if endpoint_id:
+            workflow_step_data["project_id"] = str(project_id)
 
         # Get workflow steps
         db_workflow_steps = await WorkflowStepDataManager(self.session).get_all_workflow_steps(
@@ -1038,7 +1047,7 @@ class EndpointService(SessionMixin):
         )
 
     async def _perform_bud_simulation_request(self, payload: Dict) -> Dict:
-        """Perform model extraction request."""
+        """Perform bud simulation request."""
         bud_simulation_endpoint = (
             f"{app_settings.dapr_base_url}/v1.0/invoke/{app_settings.bud_simulator_app_id}/method/simulator/run"
         )
@@ -1049,14 +1058,14 @@ class EndpointService(SessionMixin):
                 async with session.post(bud_simulation_endpoint, json=payload) as response:
                     response_data = await response.json()
                     if response.status >= 400:
-                        raise ClientException("Unable to perform model extraction")
+                        raise ClientException("Unable to perform bud simulation")
 
                     return response_data
         except ClientException as e:
             raise e
         except Exception as e:
-            logger.error(f"Failed to perform model extraction request: {e}")
-            raise ClientException("Unable to perform model extraction") from e
+            logger.error(f"Failed to perform bud simulation request: {e}")
+            raise ClientException("Unable to perform bud simulation") from e
 
     async def _perform_add_worker_to_deployment(
         self, current_step_number: int, data: Dict, db_workflow: WorkflowModel, current_user_id: UUID

--- a/budapp/workflow_ops/schemas.py
+++ b/budapp/workflow_ops/schemas.py
@@ -7,6 +7,7 @@ from budapp.model_ops.schemas import CloudModel, Model, ModelSecurityScanResult,
 
 from ..commons.constants import ModelProviderTypeEnum, WorkflowStatusEnum, WorkflowTypeEnum
 from ..endpoint_ops.schemas import EndpointResponse
+from ..project_ops.schemas import ProjectResponse
 
 
 class RetrieveWorkflowStepData(BaseModel):
@@ -41,6 +42,7 @@ class RetrieveWorkflowStepData(BaseModel):
     endpoint: EndpointResponse | None = None
     additional_concurrency: int | None = None
     bud_serve_cluster_events: dict | None = None
+    project: ProjectResponse | None = None
 
 
 class RetrieveWorkflowDataResponse(SuccessResponse):

--- a/budapp/workflow_ops/services.py
+++ b/budapp/workflow_ops/services.py
@@ -39,6 +39,8 @@ from budapp.workflow_ops.models import WorkflowStep as WorkflowStepModel
 
 from ..endpoint_ops.crud import EndpointDataManager
 from ..endpoint_ops.models import Endpoint as EndpointModel
+from ..project_ops.crud import ProjectDataManager
+from ..project_ops.models import Project as ProjectModel
 from .crud import WorkflowDataManager, WorkflowStepDataManager
 from .schemas import RetrieveWorkflowDataResponse, RetrieveWorkflowStepData, WorkflowUtilCreate
 
@@ -165,6 +167,14 @@ class WorkflowService(SessionMixin):
                 else None
             )
 
+            db_project = (
+                await ProjectDataManager(self.session).retrieve_by_fields(
+                    ProjectModel, {"id": UUID(required_data["project_id"])}, missing_ok=True
+                )
+                if "project_id" in required_data
+                else None
+            )
+
             workflow_steps = RetrieveWorkflowStepData(
                 provider_type=provider_type if provider_type else None,
                 provider=db_provider if db_provider else None,
@@ -193,6 +203,7 @@ class WorkflowService(SessionMixin):
                 endpoint=db_endpoint if db_endpoint else None,
                 additional_concurrency=additional_concurrency if additional_concurrency else None,
                 bud_simulator_events=bud_simulator_events if bud_simulator_events else None,
+                project=db_project if db_project else None,
             )
         else:
             workflow_steps = RetrieveWorkflowStepData()
@@ -264,6 +275,7 @@ class WorkflowService(SessionMixin):
                 "endpoint_id",
                 "additional_concurrency",
                 "cluster_id",
+                "project_id",
             ],
         }
 


### PR DESCRIPTION
### Title: Feature: Add Project Details to Add Worker API Response

#### Linked Issues

- Closes https://github.com/BudEcosystem/bud-serve/issues/1899

#### Description

This PR enhances the `Add Worker` API by including project details in its response. This addition improves the API's utility by providing relevant project information directly within the response.

#### Methodology/Tasks Implemented

- Updated the `Add Worker` API response schema to include project details.

#### Testing

- Tested the updated API response for accuracy and completeness.

#### Estimated Time

- Approximately 1 hours.

#### Screenshots/Logs

<img width="1379" alt="image" src="https://github.com/user-attachments/assets/adef66f6-7e93-46f3-afb4-0f1aa2c72237" />