### PR TITLE
feat: status update will fail when deployemnt/cluster under deleting …

### DIFF
--- a/budapp/endpoint_ops/services.py
+++ b/budapp/endpoint_ops/services.py
@@ -481,6 +481,11 @@ class EndpointService(SessionMixin):
         )
         logger.debug(f"Endpoint retrieved successfully: {db_endpoint.id}")
 
+        # Check if endpoint is already in deleting state
+        if db_endpoint.status == EndpointStatusEnum.DELETING:
+            logger.error("Endpoint %s is already in deleting state", db_endpoint.id)
+            raise ClientException("Endpoint is already in deleting state")
+
         # Update cluster status
         endpoint_status = await self._get_endpoint_status(payload.content.result["status"])
         db_endpoint = await EndpointDataManager(self.session).update_by_fields(


### PR DESCRIPTION
### Title: Bugfix: Prevent Status Updates for Cluster and Deployment Under Deleting Status

#### Linked Issues

- Closes https://github.com/BudEcosystem/bud-serve/issues/1956

#### Description

This PR ensures that the status of clusters and deployments does not update when they are marked as "deleting." This fix avoids inconsistent state changes during the deletion process.

#### Methodology/Tasks Implemented

- Added logic to skip status updates for clusters and deployments under the "deleting" status.
- Refactored status update methods to include checks for deletion status.
- Improved logging to capture attempts to update statuses during deletion.

#### Testing

- Verified that status updates are skipped for clusters and deployments in the "deleting" state.
- Tested scenarios where clusters and deployments are in active states to confirm unaffected functionality.
- Conducted regression testing to ensure no other areas were impacted by this change.

#### Estimated Time

- Approximately 1 hours.

#### Screenshots/Logs

<img width="1383" alt="image" src="https://github.com/user-attachments/assets/a46370e9-262f-42f5-86b1-d7c80ee71e05" />
<img width="1383" alt="image" src="https://github.com/user-attachments/assets/8ef178e3-9dd8-4504-b40d-1cf6d6b6fd28" />