### PR TITLE
fix: added project and model details

### DIFF
--- a/budapp/cluster_ops/schemas.py
+++ b/budapp/cluster_ops/schemas.py
@@ -28,7 +28,8 @@ from budapp.commons.constants import ClusterStatusEnum, EndpointStatusEnum
 from budapp.commons.schemas import PaginatedSuccessResponse, SuccessResponse
 
 from ..commons.helpers import validate_icon
-
+from ..project_ops.schemas import Project
+from ..model_ops.schemas import Model
 
 class ClusterBase(BaseModel):
     """Cluster base schema."""
@@ -214,8 +215,8 @@ class ClusterEndpointResponse(BaseModel):
     name: str
     status: EndpointStatusEnum
     created_at: datetime
-    project_name: str
-    model_name: str
+    project: Project
+    model: Model
     active_workers: int
     total_workers: int
     roi: int

--- a/budapp/cluster_ops/services.py
+++ b/budapp/cluster_ops/services.py
@@ -73,6 +73,8 @@ from .schemas import (
     MetricTypeEnum,
     ClusterDetailResponse,
 )
+from ..project_ops.schemas import Project as ProjectSchema
+from ..model_ops.schemas import Model as ModelSchema
 
 
 logger = logging.get_logger(__name__)
@@ -1078,8 +1080,8 @@ class ClusterService(SessionMixin):
         result = []
         for db_result in db_results:
             db_endpoint = db_result[0]
-            project_name = db_result[1]
-            model_name = db_result[2]
+            db_project = db_result[1]
+            db_model = db_result[2]
             total_workers = db_result[3]
             active_workers = db_result[4]
 
@@ -1088,8 +1090,8 @@ class ClusterService(SessionMixin):
                     name=db_endpoint.name,
                     status=db_endpoint.status,
                     created_at=db_endpoint.created_at,
-                    project_name=project_name,
-                    model_name=model_name,
+                    project=ProjectSchema.model_validate(db_project),
+                    model=ModelSchema.model_validate(db_model),
                     active_workers=active_workers,
                     total_workers=total_workers,
                     roi=12,  # Dummy value for ROI

--- a/budapp/endpoint_ops/crud.py
+++ b/budapp/endpoint_ops/crud.py
@@ -147,8 +147,8 @@ class EndpointDataManager(DataManagerUtils):
             stmt = (
                 select(
                     EndpointModel,
-                    ProjectModel.name.label("project_name"),
-                    Model.name.label("model_name"),
+                    ProjectModel,
+                    Model,
                     EndpointModel.total_replicas.label("total_workers"),
                     EndpointModel.active_replicas.label("active_workers"),
                 )
@@ -156,7 +156,7 @@ class EndpointDataManager(DataManagerUtils):
                 .join(Model, Model.id == EndpointModel.model_id)
                 .filter(*base_conditions)
                 .filter(and_(*search_conditions))
-                .group_by(EndpointModel.id, ProjectModel.name, Model.name)
+                .group_by(EndpointModel.id, ProjectModel.id, Model.id)
             )
 
             count_stmt = (
@@ -170,8 +170,8 @@ class EndpointDataManager(DataManagerUtils):
             stmt = (
                 select(
                     EndpointModel,
-                    ProjectModel.name.label("project_name"),
-                    Model.name.label("model_name"),
+                    ProjectModel,
+                    Model,
                     EndpointModel.total_replicas.label("total_workers"),
                     EndpointModel.active_replicas.label("active_workers"),
                 )
@@ -179,7 +179,7 @@ class EndpointDataManager(DataManagerUtils):
                 .join(Model, Model.id == EndpointModel.model_id)
                 .filter(*base_conditions)
                 .filter(*filter_conditions)
-                .group_by(EndpointModel.id, ProjectModel.name, Model.name)
+                .group_by(EndpointModel.id, ProjectModel.id, Model.id)
             )
 
             count_stmt = (
@@ -202,9 +202,9 @@ class EndpointDataManager(DataManagerUtils):
             for field, direction in order_by:
                 sort_func = asc if direction == "asc" else desc
                 if field == "project_name":
-                    stmt = stmt.order_by(sort_func("project_name"))
+                    stmt = stmt.order_by(sort_func(ProjectModel.name))
                 elif field == "model_name":
-                    stmt = stmt.order_by(sort_func("model_name"))
+                    stmt = stmt.order_by(sort_func(Model.name))
                 elif field == "total_workers":
                     stmt = stmt.order_by(sort_func("total_workers"))
                 elif field == "active_workers":

--- a/budapp/project_ops/schemas.py
+++ b/budapp/project_ops/schemas.py
@@ -103,3 +103,13 @@ class ProjectClusterFilter(BaseModel):
 
     name: str | None = None
     status: ClusterStatusEnum | None = None
+
+class Project(ProjectBase):
+    """Project response to client schema"""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID4
+    created_by: UUID4 | None = None
+    created_at: datetime
+    modified_at: datetime


### PR DESCRIPTION
# Title: Enhancement: Fetch full project and model details in endpoint response

closes: https://github.com/BudEcosystem/bud-serve/issues/1972

## Description
This PR updates the service layer to fetch the full `Project` and `Model` records instead of just their names when retrieving endpoints in a cluster. Additionally, the sorting logic by project and model names remains intact. The schema changes reflect these modifications to ensure complete data retrieval.

## Estimated Time
Approximately 1 day.

## Screenshots/logs
![image](https://github.com/user-attachments/assets/d4545a1c-b6ae-4600-84a6-d360a611b273)
