### PR TITLE
fix: query param of leaderboard request fixed

### DIFF
--- a/budapp/model_ops/services.py
+++ b/budapp/model_ops/services.py
@@ -2391,7 +2391,7 @@ class ModelService(SessionMixin):
             f"{app_settings.dapr_base_url}/v1.0/invoke/{app_settings.bud_model_app_id}/method/leaderboard/models"
         )
 
-        query_params = {"uri": uri, "k": k}
+        query_params = {"model_uri": uri, "k": k}
 
         logger.debug(f"Performing leaderboard fetch request to budmodel {query_params}")
         try:


### PR DESCRIPTION
### Title: Fix: Query Parameter Bug in Leaderboard API Call

#### Linked Issues

- Closes https://github.com/BudEcosystem/bud-serve/issues/1900

#### Description

This PR fixes an issue with incorrect query parameters in the leaderboard API call, ensuring proper data retrieval.

#### Methodology/Tasks Implemented

- Identified and corrected the incorrect query parameter usage.

#### Estimated Time

- Approximately 15 min
