### PR TITLE
refactor: added error object check for budcluster response object

### DIFF
--- a/budapp/cluster_ops/services.py
+++ b/budapp/cluster_ops/services.py
@@ -383,7 +383,7 @@ class ClusterService(SessionMixin):
                                 response_data = await response.json()
                                 logger.debug(f"Response from budcluster service: {response_data}")
 
-                                if response.status != 200:
+                                if response.status != 200 or response_data.get("object") == "error":
                                     error_message = response_data.get("message", "Failed to create cluster")
                                     logger.error(f"Failed to create cluster with external service: {error_message}")
                                     raise ClientException(error_message)
@@ -853,7 +853,7 @@ class ClusterService(SessionMixin):
             async with aiohttp.ClientSession() as session:
                 async with session.post(delete_cluster_endpoint, json=payload) as response:
                     response_data = await response.json()
-                    if response.status != 200:
+                    if response.status != 200 or response_data.get("object") == "error":
                         logger.error(f"Failed to delete cluster: {response.status} {response_data}")
                         raise ClientException(
                             "Failed to delete cluster", status_code=status.HTTP_500_INTERNAL_SERVER_ERROR
@@ -1013,7 +1013,7 @@ class ClusterService(SessionMixin):
         try:
             async with aiohttp.ClientSession() as session, session.post(cancel_cluster_endpoint) as response:
                 response_data = await response.json()
-                if response.status != 200:
+                if response.status != 200 or response_data.get("object") == "error":
                     logger.error(f"Failed to cancel cluster onboarding: {response.status} {response_data}")
                     raise ClientException(
                         "Failed to cancel cluster onboarding", status_code=status.HTTP_500_INTERNAL_SERVER_ERROR
@@ -1045,7 +1045,7 @@ class ClusterService(SessionMixin):
                 update_cluster_endpoint, json=payload
             ) as response:
                 response_data = await response.json()
-                if response.status != 200:
+                if response.status != 200 or response_data.get("object") == "error":
                     logger.error(f"Failed to update cluster node status: {response.status} {response_data}")
                     raise ClientException(
                         "Failed to update cluster node status", status_code=status.HTTP_500_INTERNAL_SERVER_ERROR

--- a/budapp/endpoint_ops/services.py
+++ b/budapp/endpoint_ops/services.py
@@ -194,7 +194,7 @@ class EndpointService(SessionMixin):
             async with aiohttp.ClientSession() as session:
                 async with session.post(delete_endpoint_url, json=payload) as response:
                     response_data = await response.json()
-                    if response.status != 200:
+                    if response.status != 200 or response_data.get("object") == "error":
                         logger.error(f"Failed to delete endpoint: {response.status} {response_data}")
                         raise ClientException("Failed to delete endpoint")
 
@@ -447,7 +447,7 @@ class EndpointService(SessionMixin):
                 update_cluster_endpoint, json=payload
             ) as response:
                 response_data = await response.json()
-                if response.status != 200:
+                if response.status != 200 or response_data.get("object") == "error":
                     logger.error(f"Failed to update endpoint status: {response.status} {response_data}")
                     raise ClientException(
                         "Failed to update endpoint status", status_code=status.HTTP_500_INTERNAL_SERVER_ERROR
@@ -567,7 +567,7 @@ class EndpointService(SessionMixin):
         async with aiohttp.ClientSession() as session:
             async with session.get(get_workers_endpoint, params=payload, headers=headers) as response:
                 response_data = await response.json()
-                if response.status != 200:
+                if response.status != 200 or response_data.get("object") == "error":
                     error_message = response_data.get("message", "Failed to get endpoint workers")
                     logger.error(f"Failed to get endpoint workers: {error_message}")
                     raise ClientException(error_message)
@@ -587,7 +587,7 @@ class EndpointService(SessionMixin):
                 get_worker_detail_endpoint, headers=headers, params={"reload": str(reload).lower()}
             ) as response:
                 response_data = await response.json()
-                if response.status != 200:
+                if response.status != 200 or response_data.get("object") == "error":
                     error_message = response_data.get("message", "Failed to get endpoint worker detail")
                     logger.error(f"Failed to get endpoint worker detail: {error_message}")
                     raise ClientException(error_message)
@@ -728,7 +728,7 @@ class EndpointService(SessionMixin):
                 delete_worker_endpoint, json=payload
             ) as response:
                 response_data = await response.json()
-                if response.status != 200:
+                if response.status != 200 or response_data.get("object") == "error":
                     logger.error(f"Failed to delete worker: {response.status} {response_data}")
                     error_message = response_data.get("message", "Failed to delete worker")
                     raise ClientException(error_message, status_code=response.status)
@@ -1177,7 +1177,7 @@ class EndpointService(SessionMixin):
             async with aiohttp.ClientSession() as session:
                 async with session.post(add_worker_endpoint, json=payload) as response:
                     response_data = await response.json()
-                    if response.status >= 400:
+                    if response.status >= 400 or response_data.get("object") == "error":
                         raise ClientException("Unable to perform add worker to deployment")
 
                     return response_data

--- a/budapp/model_ops/services.py
+++ b/budapp/model_ops/services.py
@@ -2069,7 +2069,7 @@ class ModelService(SessionMixin):
         try:
             async with aiohttp.ClientSession() as session, session.post(cancel_model_deployment_endpoint) as response:
                 response_data = await response.json()
-                if response.status != 200:
+                if response.status != 200 or response_data.get("object") == "error":
                     logger.error(f"Failed to cancel model deployment: {response.status} {response_data}")
                     raise ClientException(
                         "Failed to cancel model deployment", status_code=status.HTTP_500_INTERNAL_SERVER_ERROR


### PR DESCRIPTION
### Title: Feature: Add Response Check for Error Object in BudCluster Microframework

#### Linked Issues

- Closes https://github.com/BudEcosystem/bud-serve/issues/2058

#### Description

This PR adds a response check to identify and handle error objects in the BudCluster microframework response, ensuring more robust error handling.

#### Methodology/Tasks Implemented

- Added validation logic to detect error objects in the response.

#### Estimated Time

- Approximately 1 hours.