### PR TITLE
Fix/redis delete

### DIFF
--- a/budapp/endpoint_ops/services.py
+++ b/budapp/endpoint_ops/services.py
@@ -252,6 +252,7 @@ class EndpointService(SessionMixin):
         try:
             redis_service = RedisService()
             endpoint_redis_keys = await redis_service.keys(f"router_config:*:{db_endpoint.name}")
+            logger.debug(f"Endpoint redis keys: {endpoint_redis_keys}")
             endpoint_redis_keys_count = await redis_service.delete(*endpoint_redis_keys)
             logger.debug(f"Deleted endpoint data from redis: {endpoint_redis_keys_count} keys")
         except (RedisException, Exception) as e:

--- a/budapp/shared/redis_service.py
+++ b/budapp/shared/redis_service.py
@@ -79,8 +79,12 @@ class RedisService:
                 logger.exception(f"Error getting Redis keys: {e}")
                 raise RedisException("Error getting Redis keys") from e
 
-    async def delete(self, *names: KeyT) -> ResponseT:
+    async def delete(self, *names: Optional[KeyT]) -> ResponseT:
         """Delete a key from Redis."""
+        if not names:
+            logger.warning("No keys to delete")
+            return 0
+
         async with self.redis_singleton as redis:
             try:
                 return await redis.delete(*names)


### PR DESCRIPTION
### Title: Add Redis Key Existence Check Before Deletion

#### Description

This PR adds a condition to verify the existence of a Redis key before attempting to delete it, preventing unnecessary errors when the key does not exist.

#### Methodology/Tasks Implemented

- Implemented a Redis key existence check before performing a delete operation.
- Ensured that the deletion logic is only triggered if the key is present in Redis.

#### Estimated Time

- Approximately 1 hour.

#### Screenshots/Logs

<img width="1051" alt="image" src="https://github.com/user-attachments/assets/d3d48cd0-11f9-48ab-87aa-e999ffee5db0" />