### PR TITLE
Fix/top leaderboard api

### DIFF
--- a/budapp/model_ops/model_routes.py
+++ b/budapp/model_ops/model_routes.py
@@ -58,6 +58,7 @@ from .schemas import (
     RecommendedTagsResponse,
     TagsListResponse,
     TasksListResponse,
+    TopLeaderboardRequest,
     TopLeaderboardResponse,
 )
 from .services import (
@@ -163,7 +164,7 @@ async def list_all_models(
     ).to_http_response()
 
 
-@model_router.get(
+@model_router.post(
     "/top-leaderboards",
     responses={
         status.HTTP_500_INTERNAL_SERVER_ERROR: {
@@ -184,33 +185,11 @@ async def list_all_models(
 async def list_top_leaderboards(
     current_user: Annotated[User, Depends(get_current_active_user)],
     session: Annotated[Session, Depends(get_session)],
-    benchmarks: List[
-        Literal[
-            "bcfl",
-            "live_code_bench",
-            "classification",
-            "clustering",
-            "pair_classification",
-            "reranking",
-            "retrieval",
-            "semantic",
-            "summarization",
-            "mmbench",
-            "mmstar",
-            "mmmu",
-            "math_vista",
-            "ocr_bench",
-            "ai2d",
-            "hallucination_bench",
-            "mmvet",
-            "lmsys_areana",
-        ]
-    ] = Query(..., description="The benchmarks to list"),
-    k: int = Query(5, ge=1, description="Maximum number of leaderboards"),
+    request: TopLeaderboardRequest,
 ) -> Union[TopLeaderboardResponse, ErrorResponse]:
     """List top leaderboards."""
     try:
-        leaderboards = await ModelService(session).get_top_leaderboards(benchmarks, k)
+        leaderboards = await ModelService(session).get_top_leaderboards(request.benchmarks, request.k)
         return TopLeaderboardResponse(
             leaderboards=leaderboards,
             code=status.HTTP_200_OK,

--- a/budapp/model_ops/schemas.py
+++ b/budapp/model_ops/schemas.py
@@ -820,3 +820,38 @@ class CancelDeploymentWorkflowRequest(BaseModel):
     """Cancel deployment workflow request schema."""
 
     workflow_id: UUID4
+
+
+class TopLeaderboardRequest(BaseModel):
+    """Top leaderboard request schema."""
+
+    benchmarks: list[
+        Literal[
+            "bcfl",
+            "live_code_bench",
+            "classification",
+            "clustering",
+            "pair_classification",
+            "reranking",
+            "retrieval",
+            "semantic",
+            "summarization",
+            "mmbench",
+            "mmstar",
+            "mmmu",
+            "math_vista",
+            "ocr_bench",
+            "ai2d",
+            "hallucination_bench",
+            "mmvet",
+            "lmsys_areana",
+        ]
+    ] = Field(..., description="The benchmarks to list")
+    k: int = Field(5, description="Maximum number of leaderboards", ge=1)
+
+    @model_validator(mode="after")
+    def validate_benchmarks(self) -> "TopLeaderboardRequest":
+        """Validate the benchmarks."""
+        if not self.benchmarks:
+            raise ValueError("Benchmarks are required")
+        return self


### PR DESCRIPTION
### Title: Change Top Leaderboard Fetching API to POST Method

#### Description

This PR changes the HTTP method for fetching the top leaderboard from GET to POST for better handling of request payloads and scalability.

#### Methodology/Tasks Implemented

- Updated the top leaderboard fetching API to use the POST method.
- Adjusted API request handling logic to accommodate the method change.
- Modified API documentation and relevant code references to reflect the new method.

#### Testing

- Verified successful leaderboard fetching using POST method.
- Tested API response correctness and performance.
- Ensured backward compatibility where necessary.

#### Estimated Time

- Approximately 1 hr.

#### Screenshots/Logs

<img width="1411" alt="image" src="https://github.com/user-attachments/assets/dceeeb3d-a7f4-469c-8bfe-49c57e264115" />

#### Additional Notes

- Changing to POST allows sending complex query parameters in the request body, improving flexibility and payload management.