### PR TITLE
fix: Update ClusterSummaryMetrics power metrics schema

### DIFF
--- a/budapp/cluster_ops/schemas.py
+++ b/budapp/cluster_ops/schemas.py
@@ -328,7 +328,7 @@ class ClusterSummaryMetrics(BaseModel):
     network_in: Optional[NetworkMetrics] = Field(default_factory=NetworkMetrics)
     network_out: Optional[NetworkOutMetrics] = Field(default_factory=NetworkOutMetrics)
     network_bandwidth: Optional[NetworkBandwidthMetrics] = Field(default_factory=NetworkBandwidthMetrics)
-    power: Optional[PowerMetrics] = Field(default_factory=PowerMetrics)
+    power: Optional[Any] = Field(default=None)
 
 
 class ClusterMetricsResponse(SuccessResponse):


### PR DESCRIPTION
- Modified ClusterSummaryMetrics to use `Any` type for power metrics
- Provides flexibility in handling power metrics with a more generic type