### PR TITLE
feat: added input output tokens in response

### DIFF
--- a/budapp/metric_ops/schemas.py
+++ b/budapp/metric_ops/schemas.py
@@ -58,6 +58,7 @@ class CountAnalyticsResponse(SuccessResponse):
     concurrency_metrics: dict | None = None
     queuing_time_metrics: dict | None = None
     global_metrics: dict | None = None
+    input_output_tokens_metrics: dict | None = None
 
 
 class PerformanceAnalyticsRequest(BaseAnalyticsRequest):

--- a/budapp/metric_ops/services.py
+++ b/budapp/metric_ops/services.py
@@ -72,6 +72,7 @@ class MetricService(SessionMixin):
             concurrency_metrics=bud_metric_response["concurrency_metrics"],
             queuing_time_metrics=bud_metric_response["queuing_time_metrics"],
             global_metrics=bud_metric_response["global_metrics"],
+            input_output_tokens_metrics=bud_metric_response["input_output_tokens_metrics"],
         )
 
     async def get_request_performance_analytics(


### PR DESCRIPTION
### Title: Add Missing `input_output_tokens` in Response

#### Linked Issues

- Closes https://github.com/BudEcosystem/bud-serve/issues/2120

#### Description

This PR fixes an issue where the `input_output_tokens` field was missing in the API response. Ensuring this field is included improves token usage tracking and data consistency.

#### Methodology/Tasks Implemented

- Added the `input_output_tokens` field to the API response.

#### Testing

- Checked API response to confirm `input_output_tokens` is included.

#### Estimated Time

- Approximately 1 hour.