### PR TITLE
fix: model size optional in leaderboard response

### DIFF
--- a/budapp/model_ops/schemas.py
+++ b/budapp/model_ops/schemas.py
@@ -589,7 +589,7 @@ class LeaderboardModelInfo(BaseModel):
     """Leaderboard model info schema."""
 
     uri: str
-    model_size: int
+    model_size: int | None = None
     is_selected: bool = False
 
 


### PR DESCRIPTION
### Title: Enhancement: Make Model Size Optional in Leaderboard Response

#### Linked Issues

- Closes https://github.com/BudEcosystem/bud-serve/issues/2178

#### Description

This PR modifies the leaderboard response to make the model size field optional. This change ensures better flexibility when handling models with missing or unknown size values.

#### Methodology/Tasks Implemented

- Updated the leaderboard response schema to make model size optional.