### PR TITLE
fix: model tree only added for huggingface models

### DIFF
--- a/budapp/model_ops/services.py
+++ b/budapp/model_ops/services.py
@@ -994,20 +994,25 @@ class LocalModelWorkflowService(SessionMixin):
             vision_config = None
 
         # Get base model relation
+        base_model = None
+        base_model_relation = None
         model_tree = model_info.get("model_tree", {})
-        base_model_relation = await self.get_base_model_relation(model_tree)
 
-        # Sanitize base model
-        base_model = model_tree.get("base_model", [])
-        if isinstance(base_model, list) and len(base_model) > 0:
-            base_model = base_model
-        elif isinstance(base_model, str):
-            base_model = [base_model]
-        base_model = normalize_value(base_model)
+        # Model tree only available for HuggingFace
+        if model_tree:
+            base_model_relation = await self.get_base_model_relation(model_tree)
 
-        # If base model is the same as the model uri, set base model to None
-        if required_data["uri"] == base_model:
-            base_model = None
+            # Sanitize base model
+            base_model = model_tree.get("base_model", [])
+            if isinstance(base_model, list) and len(base_model) > 0:
+                base_model = base_model
+            elif isinstance(base_model, str):
+                base_model = [base_model]
+            base_model = normalize_value(base_model)
+
+            # If base model is the same as the model uri, set base model to None
+            if required_data["uri"] == base_model:
+                base_model = None
 
         # Dummy Values
         # TODO: remove this after implementing actual service


### PR DESCRIPTION
### Title: Fix: Restrict Model Tree Consideration to Hugging Face Models

#### Linked Issues

- Closes https://github.com/BudEcosystem/bud-serve/issues/2220, https://github.com/BudEcosystem/bud-serve/issues/2219

#### Description

This PR updates the model tree logic to only consider Hugging Face models, preventing unnecessary processing for other model sources.

#### Methodology/Tasks Implemented

- Updated model tree logic to filter out non-Hugging Face models.
- Improved efficiency by avoiding redundant model tree computations.
- Ensured compatibility with existing Hugging Face model handling.

#### Testing

- Verified that only Hugging Face models are considered in the model tree.
- Tested with different model sources to ensure correct filtering.
- Checked for any unintended side effects on model loading.

#### Estimated Time

- Approximately 1 hours.