### PR TITLE
fix: icon added in model create schema

### DIFF
--- a/budapp/model_ops/schemas.py
+++ b/budapp/model_ops/schemas.py
@@ -213,6 +213,7 @@ class ModelCreate(ModelBase):
     architecture_text_config: ModelArchitectureLLMConfig | None = None
     architecture_vision_config: ModelArchitectureVisionConfig | None = None
     scan_verified: bool | None = None
+    icon: str | None = None
 
 
 class ModelDetailResponse(BaseModel):


### PR DESCRIPTION
### Title: Fix: Added Missing Icon Field in Model Create Schema

#### Linked Issues

- Closes https://github.com/BudEcosystem/bud-serve/issues/2304

#### Description

This PR adds the missing `icon` field in the model creation schema to ensure completeness and proper representation of model metadata.

#### Methodology/Tasks Implemented

- Updated model creation schema to include the `icon` field.

#### Testing

- Verified schema changes by creating models with and without the `icon` field.

#### Estimated Time

- Approximately 1 hour.