### PR TITLE
fix: updated leaderboard table

### DIFF
--- a/budapp/commons/constants.py
+++ b/budapp/commons/constants.py
@@ -2602,12 +2602,7 @@ BENCHMARK_FIELDS_TYPE_MAPPER = {
     "bcfl": "Tool Use",
     "live_code_bench": "Code Generation",
     "lc_win_rate": "Instruction Following",
-    "win_rate": "Instruction Following",  # not there in excel sheet
     "ugi_score": "Uncensored",
-    "w_10_score": "Uncensored",  # not there in excel sheet
-    "unruly_score": "Uncensored",  # not there in excel sheet
-    "internet_score": "Uncensored",  # not there in excel sheet
-    "polcontro_score": "Uncensored",  # not there in excel sheet
 }
 
 BENCHMARK_FIELDS_LABEL_MAPPER = {
@@ -2630,12 +2625,7 @@ BENCHMARK_FIELDS_LABEL_MAPPER = {
     "bcfl": "BCFL",
     "live_code_bench": "Live Code Bench",
     "lc_win_rate": "AlpacaEval2.0",
-    "win_rate": "Win Rate",  # not there in excel sheet
     "ugi_score": "UGI",
-    "w_10_score": "W/10 Score",  # not there in excel sheet
-    "unruly_score": "Unruly Score",  # not there in excel sheet
-    "internet_score": "Internet Score",  # not there in excel sheet
-    "polcontro_score": "Polcontro Score",  # not there in excel sheet
 }
 
 

--- a/budapp/model_ops/schemas.py
+++ b/budapp/model_ops/schemas.py
@@ -603,7 +603,6 @@ class Leaderboard(BaseModel):
 
     # APAC Eval Leaderboard fields
     lc_win_rate: float | None = None
-    win_rate: float | None = None
 
     # Berkeley Leaderboard fields
     bcfl: float | None = None
@@ -622,13 +621,6 @@ class Leaderboard(BaseModel):
 
     # UGI Leaderboard fields (with _score suffixes)
     ugi_score: float | None = None
-    w_10_score: float | None = None
-    # i_10_score: str | None = None  # TODO: Uncomment this column when scraper bug is fixed
-    unruly_score: float | None = None
-    internet_score: float | None = None
-    # stats_score: str | None = None  # TODO: Uncomment this column when scraper bug is fixed
-    # writing_score: str | None = None  # TODO: Uncomment this column when scraper bug is fixed
-    polcontro_score: float | None = None
 
     # VLLM Leaderboard fields
     mmbench: float | None = None
@@ -887,7 +879,6 @@ class TopLeaderboardRequest(BaseModel):
     benchmarks: list[
         Literal[
             "lc_win_rate",
-            "win_rate",
             "bcfl",
             "live_code_bench",
             "classification",
@@ -898,10 +889,6 @@ class TopLeaderboardRequest(BaseModel):
             "semantic",
             "summarization",
             "ugi_score",
-            "w_10_score",
-            "unruly_score",
-            "internet_score",
-            "polcontro_score",
             "mmbench",
             "mmstar",
             "mmmu",


### PR DESCRIPTION
# Leaderboard Schema Update

## Description
This PR updates the `Leaderboard` schema by adding new fields for the **APAC Eval** and **UGI** leaderboards. It also includes `TODO` comments for future columns that need to be uncommented once the scraper bug is fixed.

## Schema Changes

### Added Fields

#### APAC Eval Leaderboard Fields
- `lc_win_rate`: `float | None` – LC win rate score.
- `win_rate`: `float | None` – Overall win rate score.

#### UGI Leaderboard Fields
- `ugi_score`: `float | None` – UGI evaluation score.
- `w_10_score`: `float | None` – W10 evaluation score.
- `unruly_score`: `float | None` – Unruly evaluation score.
- `internet_score`: `float | None` – Internet evaluation score.
- `polcontro_score`: `float | None` – Polcontro evaluation score.
- `# i_10_score`: `str | None` – (TODO: Uncomment when scraper bug is fixed.)
- `# stats_score`: `str | None` – (TODO: Uncomment when scraper bug is fixed.)
- `# writing_score`: `str | None` – (TODO: Uncomment when scraper bug is fixed.)

## Existing Fields
No changes were made to the existing leaderboard fields, including:
- **Berkeley Leaderboard**
- **LiveCodeBench Leaderboard**
- **MTEB Leaderboard**
- **VLLM Leaderboard**
- **Chatbot Arena Leaderboard**

## Screenshots

![image](https://github.com/user-attachments/assets/d493a1ef-1f21-4d45-b66a-58fcfbd193d4)

![image](https://github.com/user-attachments/assets/a49183db-d148-4045-a8c0-012f3a4ab19b)

