### PR TITLE
refactor: modified metric services

### DIFF
--- a/budapp/metric_ops/metric_routes.py
+++ b/budapp/metric_ops/metric_routes.py
@@ -44,7 +44,7 @@ from .schemas import (
     PerformanceAnalyticsRequest,
     PerformanceAnalyticsResponse,
 )
-from .services import MetricService
+from .services import BudMetricService, MetricService
 
 
 logger = logging.get_logger(__name__)
@@ -72,12 +72,12 @@ metric_router = APIRouter(prefix="/metrics", tags=["metric"])
 )
 async def get_request_count_analytics(
     current_user: Annotated[User, Depends(get_current_active_user)],
-    session: Annotated[Session, Depends(get_session)],
+    # session: Annotated[Session, Depends(get_session)],
     metric_request: CountAnalyticsRequest,
 ) -> Union[CountAnalyticsResponse, ErrorResponse]:
     """Get request count analytics."""
     try:
-        return await MetricService(session).get_request_count_analytics(metric_request)
+        return await BudMetricService().get_request_count_analytics(metric_request)
     except ClientException as e:
         logger.exception(f"Failed to get request count analytics: {e}")
         return ErrorResponse(code=e.status_code, message=e.message).to_http_response()
@@ -108,12 +108,12 @@ async def get_request_count_analytics(
 )
 async def get_request_performance_analytics(
     current_user: Annotated[User, Depends(get_current_active_user)],
-    session: Annotated[Session, Depends(get_session)],
+    # session: Annotated[Session, Depends(get_session)],
     metric_request: PerformanceAnalyticsRequest,
 ) -> Union[PerformanceAnalyticsResponse, ErrorResponse]:
     """Get request performance analytics."""
     try:
-        return await MetricService(session).get_request_performance_analytics(metric_request)
+        return await BudMetricService().get_request_performance_analytics(metric_request)
     except ClientException as e:
         logger.exception(f"Failed to get request performance analytics: {e}")
         return ErrorResponse(code=e.status_code, message=e.message).to_http_response()
@@ -189,13 +189,13 @@ async def get_dashboard_stats(
 async def get_deployment_cache_metric(
     endpoint_id: UUID,
     _: Annotated[User, Depends(get_current_active_user)],
-    session: Annotated[Session, Depends(get_session)],
+    # session: Annotated[Session, Depends(get_session)],
     page: int = 1,
     limit: int = 10,
 ) -> Union[CacheMetricsResponse, ErrorResponse]:
     """Get deployment cache metrics."""
     try:
-        response = await MetricService(session).get_deployment_cache_metric(endpoint_id, page=page, limit=limit)
+        response = await BudMetricService().get_deployment_cache_metric(endpoint_id, page=page, limit=limit)
     except ClientException as e:
         logger.exception(f"Failed to get deployment cache metrics: {e}")
         return ErrorResponse(code=e.status_code, message=e.message)
@@ -227,11 +227,11 @@ async def get_deployment_cache_metric(
 async def get_inference_quality_score_analytics(
     endpoint_id: UUID,
     _: Annotated[User, Depends(get_current_active_user)],
-    session: Annotated[Session, Depends(get_session)],
+    # session: Annotated[Session, Depends(get_session)],
 ) -> Union[InferenceQualityAnalyticsResponse, ErrorResponse]:
     """Get inference quality score analytics."""
     try:
-        response = await MetricService(session).get_inference_quality_analytics(endpoint_id)
+        response = await BudMetricService().get_inference_quality_analytics(endpoint_id)
     except ClientException as e:
         logger.exception(f"Failed to get inference quality score analytics: {e}")
         response = ErrorResponse(code=e.status_code, message=e.message)
@@ -264,7 +264,7 @@ async def get_inference_quality_prompt_analytics(
     endpoint_id: UUID,
     score_type: Literal["hallucination", "harmfulness", "sensitive_info", "prompt_injection"],
     _: Annotated[User, Depends(get_current_active_user)],
-    session: Annotated[Session, Depends(get_session)],
+    # session: Annotated[Session, Depends(get_session)],
     filters: Annotated[InferenceQualityAnalyticsPromptFilter, Depends()],
     search: bool = False,
     order_by: Optional[List[str]] = Depends(parse_ordering_fields),
@@ -274,7 +274,7 @@ async def get_inference_quality_prompt_analytics(
     """Get inference quality prompt analytics."""
     try:
         order_by_str = ",".join(":".join(item) for item in order_by)
-        response = await MetricService(session).get_inference_quality_prompt_analytics(endpoint_id, score_type, page, limit, filters, search, order_by_str if order_by_str else "created_at:desc")
+        response = await BudMetricService().get_inference_quality_prompt_analytics(endpoint_id, score_type, page, limit, filters, search, order_by_str if order_by_str else "created_at:desc")
     except ClientException as e:
         logger.exception(f"Failed to get inference quality prompt analytics: {e}")
         response = ErrorResponse(code=e.status_code, message=e.message)

--- a/budapp/metric_ops/services.py
+++ b/budapp/metric_ops/services.py
@@ -58,8 +58,8 @@ from .schemas import (
 logger = logging.get_logger(__name__)
 
 
-class MetricService(SessionMixin):
-    """Metric service."""
+class BudMetricService:
+    """Bud Metric service."""
 
     async def get_request_count_analytics(
         self,
@@ -157,63 +157,6 @@ class MetricService(SessionMixin):
             raise ClientException(
                 "Failed to get request performance analytics", status_code=status.HTTP_500_INTERNAL_SERVER_ERROR
             ) from e
-
-    async def get_dashboard_stats(self, user_id: UUID) -> DashboardStatsResponse:
-        """Fetch dashboard statistics for the given user."""
-        db_total_model_count = await ModelDataManager(self.session).get_count_by_fields(
-            Model, fields={"status": ModelStatusEnum.ACTIVE}
-        )
-        db_cloud_model_count = await ModelDataManager(self.session).get_count_by_fields(
-            Model,
-            fields={
-                "status": ModelStatusEnum.ACTIVE,
-                "provider_type": ModelProviderTypeEnum.CLOUD_MODEL,
-            },
-        )
-        db_local_model_count = await ModelDataManager(self.session).get_count_by_fields(
-            Model,
-            fields={"status": ModelStatusEnum.ACTIVE},
-            exclude_fields={"provider_type": ModelProviderTypeEnum.CLOUD_MODEL},
-        )
-        db_total_endpoint_count = await EndpointDataManager(self.session).get_count_by_fields(
-            EndpointModel, fields={}, exclude_fields={"status": EndpointStatusEnum.DELETED}
-        )
-        db_running_endpoint_count = await EndpointDataManager(self.session).get_count_by_fields(
-            EndpointModel, fields={"status": EndpointStatusEnum.RUNNING}
-        )
-
-        db_total_clusters = await ClusterDataManager(self.session).get_count_by_fields(
-            ClusterModel, fields={}, exclude_fields={"status": ClusterStatusEnum.DELETED}
-        )
-
-        _, db_inactive_clusters = await ClusterDataManager(self.session).get_inactive_clusters()
-
-        db_project_count = await ProjectDataManager(self.session).get_count_by_fields(
-            ProjectModel, fields={"status": ProjectStatusEnum.ACTIVE}
-        )
-
-        db_total_project_users = ProjectDataManager(self.session).get_unique_user_count_in_all_projects()
-
-        db_dashboard_stats = {
-            "total_model_count": db_total_model_count,
-            "cloud_model_count": db_cloud_model_count,
-            "local_model_count": db_local_model_count,
-            "total_projects": db_project_count,
-            "total_project_users": db_total_project_users,
-            "total_endpoints_count": db_total_endpoint_count,
-            "running_endpoints_count": db_running_endpoint_count,
-            "total_clusters": db_total_clusters,
-            "inactive_clusters": db_inactive_clusters,
-        }
-
-        db_dashboard_stats = DashboardStatsResponse(
-            code=status.HTTP_200_OK,
-            object="dashboard.count",
-            message="Successfully fetched dashboard count statistics",
-            **db_dashboard_stats,
-        )
-
-        return db_dashboard_stats
 
     @staticmethod
     async def _perform_deployment_cache_metric(endpoint_id: UUID, page: int = 1, limit: int = 10) -> Dict:
@@ -367,3 +310,64 @@ class MetricService(SessionMixin):
             message="Successfully fetched inference quality prompt analytics",
             **bud_metric_response,
         )
+
+
+class MetricService(SessionMixin):
+    """Metric service."""
+
+    async def get_dashboard_stats(self, user_id: UUID) -> DashboardStatsResponse:
+        """Fetch dashboard statistics for the given user."""
+        db_total_model_count = await ModelDataManager(self.session).get_count_by_fields(
+            Model, fields={"status": ModelStatusEnum.ACTIVE}
+        )
+        db_cloud_model_count = await ModelDataManager(self.session).get_count_by_fields(
+            Model,
+            fields={
+                "status": ModelStatusEnum.ACTIVE,
+                "provider_type": ModelProviderTypeEnum.CLOUD_MODEL,
+            },
+        )
+        db_local_model_count = await ModelDataManager(self.session).get_count_by_fields(
+            Model,
+            fields={"status": ModelStatusEnum.ACTIVE},
+            exclude_fields={"provider_type": ModelProviderTypeEnum.CLOUD_MODEL},
+        )
+        db_total_endpoint_count = await EndpointDataManager(self.session).get_count_by_fields(
+            EndpointModel, fields={}, exclude_fields={"status": EndpointStatusEnum.DELETED}
+        )
+        db_running_endpoint_count = await EndpointDataManager(self.session).get_count_by_fields(
+            EndpointModel, fields={"status": EndpointStatusEnum.RUNNING}
+        )
+
+        db_total_clusters = await ClusterDataManager(self.session).get_count_by_fields(
+            ClusterModel, fields={}, exclude_fields={"status": ClusterStatusEnum.DELETED}
+        )
+
+        _, db_inactive_clusters = await ClusterDataManager(self.session).get_inactive_clusters()
+
+        db_project_count = await ProjectDataManager(self.session).get_count_by_fields(
+            ProjectModel, fields={"status": ProjectStatusEnum.ACTIVE}
+        )
+
+        db_total_project_users = ProjectDataManager(self.session).get_unique_user_count_in_all_projects()
+
+        db_dashboard_stats = {
+            "total_model_count": db_total_model_count,
+            "cloud_model_count": db_cloud_model_count,
+            "local_model_count": db_local_model_count,
+            "total_projects": db_project_count,
+            "total_project_users": db_total_project_users,
+            "total_endpoints_count": db_total_endpoint_count,
+            "running_endpoints_count": db_running_endpoint_count,
+            "total_clusters": db_total_clusters,
+            "inactive_clusters": db_inactive_clusters,
+        }
+
+        db_dashboard_stats = DashboardStatsResponse(
+            code=status.HTTP_200_OK,
+            object="dashboard.count",
+            message="Successfully fetched dashboard count statistics",
+            **db_dashboard_stats,
+        )
+
+        return db_dashboard_stats


### PR DESCRIPTION
### Title: Chore: Remove Unnecessary DB Session from Metric APIs

#### Description

This PR removes redundant database session initializations from metric-related API endpoints. The change improves code efficiency and clarity by ensuring sessions are only opened when absolutely necessary.

#### Methodology/Tasks Implemented

- Removed unused session instances and related logic.
- Verified that all functional paths still behave as expected without session.

#### Testing

- Manually tested all metric endpoints.
- Ensured no regressions or errors in API responses after changes.

#### Estimated Time

- Approximately 4 hour.

#### Screenshots/Logs

metrics/analytics/request-counts
<img width="1437" alt="image" src="https://github.com/user-attachments/assets/3b30dc45-1e93-47b3-b4fb-040da510b6db" />

metrics/analytics/request-performance
<img width="1437" alt="image" src="https://github.com/user-attachments/assets/214393f4-4ec6-4a96-88b7-850842cc5fe2" />

metrics/count
<img width="1437" alt="image" src="https://github.com/user-attachments/assets/e1276708-de9d-43f4-b042-5bb630aca6f4" />

metrics/analytics/cache-metrics/805f9243-158b-4883-b35e-e11262b53989?page=1&limit=10
<img width="1437" alt="image" src="https://github.com/user-attachments/assets/34821d76-e1e2-484b-af9d-425e62299d41" />

http://localhost:9081/metrics/analytics/inference-quality/805f9243-158b-4883-b35e-e11262b53989
<img width="1437" alt="image" src="https://github.com/user-attachments/assets/969b1454-6139-4f9b-af09-c1a2b576421b" />

metrics/analytics/inference-quality-prompts/805f9243-158b-4883-b35e-e11262b53989/hallucination?search=false&page=1&limit=10&min_score=0&max_score=1
<img width="1437" alt="image" src="https://github.com/user-attachments/assets/103103d3-9db8-44e0-80dc-8453eacdb804" />