### PR TITLE
fix: fixed blank icon for disk and url

### DIFF
--- a/budapp/model_ops/services.py
+++ b/budapp/model_ops/services.py
@@ -1073,10 +1073,10 @@ class LocalModelWorkflowService(SessionMixin):
             )
             provider_id = db_provider.id
 
-        elif required_data["provider_type"] == ModelProviderTypeEnum.DISK:
+        elif required_data["provider_type"] == ModelProviderTypeEnum.DISK.value:
             if not icon:
                 icon = APP_ICONS["general"]["default_disk_model"]
-        elif required_data["provider_type"] == ModelProviderTypeEnum.URL:
+        elif required_data["provider_type"] == ModelProviderTypeEnum.URL.value:
             if not icon:
                 icon = APP_ICONS["general"]["default_url_model"]
 


### PR DESCRIPTION
# Fix: blank icon for disk models

## Description
This PR fixes the blank icon issue for local models(disk,url) when icon is not given by user and is not found during model extraction.
closes: https://github.com/BudEcosystem/bud-serve/issues/2493