### PR TITLE
fix: added a fix for empty benchmark list in list leadeboard api

### DIFF
--- a/budapp/model_ops/services.py
+++ b/budapp/model_ops/services.py
@@ -2619,8 +2619,8 @@ class ModelService(SessionMixin):
                         value=bud_model_benchmark.get("eval_score"),
                         label=BENCHMARK_FIELDS_LABEL_MAPPER.get(field, label_alternative),
                     )
-
-            leaderboard_tables.append(LeaderboardTable(model=model, benchmarks=benchmarks))
+            if benchmarks:
+                leaderboard_tables.append(LeaderboardTable(model=model, benchmarks=benchmarks))
 
         return leaderboard_tables
 


### PR DESCRIPTION
# fix: added a fix for empty benchmark list in list leadeboard api

## Description

This PR adds fix for empty list leaderboard by skipping them in parser.