### PR TITLE
feat: added default license name

### DIFF
--- a/budapp/model_ops/services.py
+++ b/budapp/model_ops/services.py
@@ -2586,8 +2586,9 @@ class ModelService(SessionMixin):
                     }
                 )
 
+        license_name = normalize_value(license_details.get("name", "license"))
         license_data = {
-            "name": normalize_value(license_details.get("name", "license")),
+            "name": license_name if license_name else "license",
             "license_type": normalize_value(license_details.get("type")),
             "description": normalize_value(license_details.get("type_description")),
             "suitability": normalize_value(license_details.get("type_suitability")),


### PR DESCRIPTION
### Title: Enhancement: Added Default Name for License FAQ

#### Description

This PR introduces a default name for license FAQ entries to ensure consistency and prevent issues arising from missing or undefined names during license processing and retrieval.

#### Methodology/Tasks Implemented

- Added fallback default name assignment logic for license FAQ.
- Ensured compatibility with existing license extraction and display workflows.

#### Testing

- Verified that license FAQ entries without names are assigned the default name.
- Confirmed expected behavior across retrieval and display endpoints.