### PR TITLE
feat: added remove_license boolean to delete license file from model …

### DIFF
--- a/budapp/model_ops/model_routes.py
+++ b/budapp/model_ops/model_routes.py
@@ -381,6 +381,7 @@ async def edit_model(
     website_url: str | None = Form(None),
     license_file: UploadFile | None = None,
     license_url: str | None = Form(None),
+    remove_license: bool = Form(False),
 ) -> Union[SuccessResponse, ErrorResponse]:
     """Edit cloud model with file upload"""
     logger.debug(
@@ -416,6 +417,7 @@ async def edit_model(
             website_url=website_url if website_url else None,
             license_url=license_url if license_url else None,
             license_file=license_file if license_file else None,
+            remove_license=remove_license,
         )
 
         # Pass file and edit_model data to your service

--- a/budapp/model_ops/schemas.py
+++ b/budapp/model_ops/schemas.py
@@ -470,6 +470,7 @@ class EditModel(BaseModel):
     website_url: HttpUrl | None = None
     license_file: UploadFile | None = None
     license_url: HttpUrl | None = None
+    remove_license: bool = False
 
     @field_validator("name", mode="before")
     def validate_name(cls, value: Optional[str]) -> Optional[str]:


### PR DESCRIPTION
### Title: Feature: Support Removing License in Edit Model API

#### Linked Issues

- Closes https://github.com/BudEcosystem/bud-serve/issues/2582

#### Description

This PR adds support for removing the existing license associated with a model through the edit model API. This enables users to update or delete previously attached license information.

#### Methodology/Tasks Implemented

- Updated edit model API to handle license removal requests.
- Adjusted backend logic to clean up license data and associated minio files if removal is requested.
- Ensured compatibility with license validation and existing upload logic.

#### Testing

- Verified that license can be removed successfully via the edit API.
- Tested scenarios with and without new license replacement.
- Confirmed minio cleanup and database updates occur as expected.

#### Estimated Time

- Approximately 2 hours.

#### Screenshots/Logs

<img width="1053" alt="image" src="https://github.com/user-attachments/assets/4c62a92e-b0f9-481d-8e00-85e320922148" />

#### Additional Notes

- This functionality ensures better flexibility and control over license management.