### PR TITLE
fix: changed source to string in cloud model onboarding

### DIFF
--- a/budapp/model_ops/schemas.py
+++ b/budapp/model_ops/schemas.py
@@ -41,7 +41,6 @@ from budapp.commons.constants import (
     ModelEndpointEnum,
     ModelProviderTypeEnum,
     ModelSecurityScanStatusEnum,
-    ModelSourceEnum,
     WorkflowStatusEnum,
 )
 from budapp.commons.schemas import PaginatedSuccessResponse, SuccessResponse, Tag, Task
@@ -218,7 +217,7 @@ class Model(ModelBase):
     id: UUID4
     icon: str | None = None
     modality: List[ModalityEnum]
-    source: ModelSourceEnum
+    source: str
     provider_type: ModelProviderTypeEnum
     uri: str
     model_size: Optional[int] = None


### PR DESCRIPTION
### Title: Refactor: Change Model Source from Enum to String

#### Description

This PR updates the model source field to use a plain string instead of an enum type. This change simplifies data handling and increases flexibility in specifying model sources.

#### Methodology/Tasks Implemented

- Replaced `ModelSourceEnum` with `string` type in all relevant schema and database references.
- Updated associated validation and serialization logic.
- Adjusted any dependent components consuming the model source field.