### PR TITLE
Update model endpoint counts

### DIFF
--- a/budapp/model_ops/services.py
+++ b/budapp/model_ops/services.py
@@ -1961,9 +1961,7 @@ class ModelService(SessionMixin):
             quantizations_count=base_model_relation_count.get(BaseModelRelationEnum.QUANTIZED.value, 0),
         )
 
-        db_endpoint_count = await ModelDataManager(self.session).get_count_by_fields(
-            EndpointModel, fields={"model_id": model_id}, exclude_fields={"status": EndpointStatusEnum.DELETED}
-        )
+        db_endpoint_count = await ModelDataManager(self.session).get_model_endpoints_count(model_id)
 
         return ModelDetailSuccessResponse(
             model=db_model,


### PR DESCRIPTION
## Summary
- include adapter status when counting model endpoints
- expose helper to get endpoint counts from adapters and base models

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*