### PR TITLE
feat: benchmark filter api added

### DIFF
--- a/budapp/benchmark_ops/benchmark_routes.py
+++ b/budapp/benchmark_ops/benchmark_routes.py
@@ -38,7 +38,15 @@ from budapp.user_ops.schemas import User
 from budapp.workflow_ops.schemas import RetrieveWorkflowDataResponse
 from budapp.workflow_ops.services import WorkflowService
 
-from .schemas import AddRequestMetricsRequest, BenchmarkFilter, BenchmarkPaginatedResponse, RunBenchmarkWorkflowRequest
+from ..commons.constants import BenchmarkFilterResourceEnum
+from .schemas import (
+    AddRequestMetricsRequest,
+    BenchmarkFilter,
+    BenchmarkFilterFields,
+    BenchmarkFilterValueResponse,
+    BenchmarkPaginatedResponse,
+    RunBenchmarkWorkflowRequest,
+)
 from .services import BenchmarkRequestMetricsService, BenchmarkService
 
 
@@ -143,6 +151,55 @@ async def list_all_benchmarks(
         object="benchmarks.list",
         code=status.HTTP_200_OK,
         message="Successfully list all benchmarks",
+    ).to_http_response()
+
+
+@benchmark_router.get(
+    "/filters",
+    responses={
+        status.HTTP_500_INTERNAL_SERVER_ERROR: {
+            "model": ErrorResponse,
+            "description": "Service is unavailable due to server error",
+        },
+        status.HTTP_400_BAD_REQUEST: {
+            "model": ErrorResponse,
+            "description": "Service is unavailable due to client error",
+        },
+        status.HTTP_200_OK: {
+            "model": BenchmarkFilterValueResponse,
+            "description": "Successfully list all benchmark filters",
+        },
+    },
+    description="List unique benchmark filter values",
+)
+async def list_all_benchmark_filters(
+    _: Annotated[User, Depends(get_current_active_user)],
+    session: Annotated[Session, Depends(get_session)],
+    filters: Annotated[BenchmarkFilterFields, Depends()],
+    page: int = Query(1, ge=1),
+    limit: int = Query(10, ge=0),
+    search: bool = False,
+) -> Union[BenchmarkFilterValueResponse, ErrorResponse]:
+    """List unique benchmark filter values."""
+    offset = (page - 1) * limit
+
+    # Get the name to filter by
+    if filters.resource == BenchmarkFilterResourceEnum.MODEL:
+        name = filters.model_name or None
+    else:
+        name = filters.cluster_name or None
+
+    result, count = await BenchmarkService(session).list_benchmark_filter_values(
+        filters.resource, name, search, offset, limit
+    )
+
+    return BenchmarkFilterValueResponse(
+        result=result,
+        total_record=count,
+        page=page,
+        limit=limit,
+        object="benchmarks.filters.list",
+        code=status.HTTP_200_OK,
     ).to_http_response()
 
 

--- a/budapp/benchmark_ops/models.py
+++ b/budapp/benchmark_ops/models.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 from uuid import UUID, uuid4
 
 from budmicroframe.shared.psql_service import CRUDMixin, PSQLBase, TimestampMixin
@@ -16,10 +16,10 @@ from sqlalchemy import (
     select,
 )
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, Session, mapped_column, relationship
 
 from ..cluster_ops.models import Cluster as ClusterModel
-from ..commons.constants import BenchmarkStatusEnum
+from ..commons.constants import BenchmarkFilterResourceEnum, BenchmarkStatusEnum
 from ..model_ops.models import Model
 
 
@@ -205,6 +205,60 @@ class BenchmarkCRUD(CRUDMixin[BenchmarkSchema, None, None]):
         print(stmt)
 
         result = self.scalars_all(stmt)
+
+        return result, count
+
+    async def list_unique_model_cluster_names(
+        self,
+        resource: BenchmarkFilterResourceEnum,
+        value: str,
+        search: bool,
+        offset: int,
+        limit: int,
+        session: Session,
+    ) -> Tuple[List[str], int]:
+        """List distinct model or cluster names used in benchmarks.
+
+        Args:
+            resource: The resource to filter by.
+            value: The value to filter by.
+            search: Whether to search for the value.
+            offset: The offset to start the fetch from.
+            limit: The limit to fetch.
+
+        Returns:
+            Tuple[List[str], int]: A tuple containing the list of unique model or cluster names and the total count.
+        """
+        if resource == BenchmarkFilterResourceEnum.MODEL:
+            col_name = Model.name
+            join_model = Model
+            join_condition = self.model.model_id == Model.id
+        else:
+            col_name = ClusterModel.name
+            join_model = ClusterModel
+            join_condition = self.model.cluster_id == ClusterModel.id
+
+        # Create query and count query
+        stmt = select(func.distinct(col_name).label("name")).select_from(self.model).join(join_model, join_condition)
+        count_stmt = (
+            select(func.count(func.distinct(col_name))).select_from(self.model).join(join_model, join_condition)
+        )
+
+        # Generate search or filter query
+        if value:
+            if search:
+                stmt = stmt.where(col_name.ilike(f"%{value}%"))
+                count_stmt = count_stmt.where(col_name.ilike(f"%{value}%"))
+            else:
+                stmt = stmt.where(col_name == value)
+                count_stmt = count_stmt.where(col_name == value)
+
+        # Apply limit and offset
+        stmt = stmt.order_by(col_name).offset(offset).limit(limit)
+
+        # Execute query
+        result = session.execute(stmt).scalars().all()
+        count = self.execute_scalar(count_stmt)
 
         return result, count
 

--- a/budapp/benchmark_ops/schemas.py
+++ b/budapp/benchmark_ops/schemas.py
@@ -2,9 +2,9 @@ from datetime import datetime
 from typing import Any, Literal, Optional
 from uuid import UUID
 
-from pydantic import UUID4, BaseModel, ConfigDict, Field, model_validator, computed_field
+from pydantic import UUID4, BaseModel, ConfigDict, Field, computed_field, model_validator
 
-from budapp.commons.constants import BenchmarkStatusEnum
+from budapp.commons.constants import BenchmarkFilterResourceEnum, BenchmarkStatusEnum
 from budapp.commons.schemas import PaginatedSuccessResponse
 
 from ..cluster_ops.schemas import ClusterResponse
@@ -205,3 +205,20 @@ class BenchmarkRequestMetrics(BaseModel):
 
 class AddRequestMetricsRequest(BaseModel):
     metrics: list[BenchmarkRequestMetrics]
+
+
+# Benchmark Filter Listing API
+
+
+class BenchmarkFilterFields(BaseModel):
+    """Benchmark filter fields schema."""
+
+    model_name: str | None = None
+    cluster_name: str | None = None
+    resource: BenchmarkFilterResourceEnum = Field(default=BenchmarkFilterResourceEnum.MODEL)
+
+
+class BenchmarkFilterValueResponse(PaginatedSuccessResponse):
+    """Benchmark filter values response schema."""
+
+    result: list[str]

--- a/budapp/benchmark_ops/services.py
+++ b/budapp/benchmark_ops/services.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 from uuid import UUID
 
 import aiohttp
@@ -16,6 +16,7 @@ from ..commons.config import app_settings
 from ..commons.constants import (
     APP_ICONS,
     BUD_INTERNAL_WORKFLOW,
+    BenchmarkFilterResourceEnum,
     BenchmarkStatusEnum,
     BudServeWorkflowStepEventName,
     ClusterStatusEnum,
@@ -529,6 +530,33 @@ class BenchmarkService(SessionMixin):
                 )
                 benchmark_list.append(benchmark_dict)
             return benchmark_list, total_count
+
+    async def list_benchmark_filter_values(
+        self,
+        resource: BenchmarkFilterResourceEnum,
+        name: str,
+        search: bool,
+        offset: int = 0,
+        limit: int = 10,
+    ) -> Tuple[List[str], int]:
+        """List distinct benchmark filter values by type.
+
+        Args:
+            resource: BenchmarkFilterResourceEnum
+            name: str
+            search: bool
+            offset: int
+            limit: int
+
+        Returns:
+            Tuple[List[str], int]: A tuple containing a list of distinct filter values and the total count of values.
+        """
+        with BenchmarkCRUD() as crud:
+            result, count = await crud.list_unique_model_cluster_names(
+                resource, name, search, offset, limit, self.session
+            )
+
+        return result, count
 
     async def _perform_get_benchmark_result_request(self, benchmark_id: UUID) -> dict:
         """Perform run benchmark request to budcluster service."""

--- a/budapp/commons/constants.py
+++ b/budapp/commons/constants.py
@@ -2868,3 +2868,10 @@ class ModelEndpointEnum(Enum):
             }
 
         return result
+
+
+class BenchmarkFilterResourceEnum(Enum):
+    """Benchmark filter resource types."""
+
+    MODEL = "model"
+    CLUSTER = "cluster"


### PR DESCRIPTION
### Title: Feature: Add API for Benchmark Listing with Filters

#### Linked Issues

- Closes https://github.com/BudEcosystem/bud-serve/issues/2647

#### Description

This PR introduces an API endpoint to list benchmarks with support for filtering, ordering, searching, pagination, and result limiting.

#### Methodology/Tasks Implemented

- Implemented benchmark listing API.
- Added support for dynamic filtering on benchmark fields.
- Enabled ordering and search capabilities.
- Integrated pagination and result limiting options for scalability.

#### Testing

- Verified filter, search, and ordering functionality using various query combinations.
- Tested pagination and limit behavior across multiple result sets.
- Ensured proper response structure and performance under load.

#### Estimated Time

- Approximately 3 hours.

<img width="1377" alt="image" src="https://github.com/user-attachments/assets/4f4e00f1-90a1-47fe-9063-8bdbc4de50ca" />
