### PR TITLE
feat: added worker count data in model cluster detail of endpoint api

### DIFF
--- a/budapp/endpoint_ops/schemas.py
+++ b/budapp/endpoint_ops/schemas.py
@@ -171,6 +171,8 @@ class ModelClusterDetail(BaseModel):
     model: ModelDetailResponse
     cluster: ClusterResponse
     deployment_config: Optional[dict] = None
+    running_worker_count: int | None = None
+    crashed_worker_count: int | None = None
 
 
 class ModelClusterDetailResponse(SuccessResponse):


### PR DESCRIPTION
### Title: Enhancement: Add Worker Count to Model Cluster Detail API

#### Linked Issues

- Closes https://github.com/BudEcosystem/bud-serve/issues/2565

#### Description

This PR enhances the model cluster detail API by including worker count data from the associated endpoint. If there is an exception during the retrieval of endpoint details, the count fields will be returned as null to ensure graceful degradation.

#### Methodology/Tasks Implemented

- Integrated worker count data in model cluster detail API response.
- Wrapped endpoint data retrieval in exception handling to set counts to null in failure scenarios.

#### Testing

- Verified worker count is correctly reflected when endpoint data is available.
- Simulated failure scenarios to confirm counts are set to null on exception.

#### Estimated Time

- Approximately 3 hours.

#### Screenshots/Logs

<img width="1386" alt="image" src="https://github.com/user-attachments/assets/c032ba0d-0729-4b4d-b721-1a1e6a38c6fa" />