### PR TITLE
feat: added eta updation in db on workflow, workflow_step table

### DIFF
--- a/budapp/commons/constants.py
+++ b/budapp/commons/constants.py
@@ -586,6 +586,28 @@ class BudServeWorkflowStepEventName(str, Enum):
     ADAPTER_DELETE_EVENTS = "adapter_delete_events"
 
 
+# Mapping between payload types and workflow step event names.
+# This mapping is used when processing asynchronous notifications to
+# determine which workflow step should be updated based on the incoming
+# payload type.
+PAYLOAD_TO_WORKFLOW_STEP_EVENT: dict[PayloadType, BudServeWorkflowStepEventName] = {
+    PayloadType.DEPLOYMENT_RECOMMENDATION: BudServeWorkflowStepEventName.BUD_SIMULATOR_EVENTS,
+    PayloadType.DEPLOY_MODEL: BudServeWorkflowStepEventName.BUDSERVE_CLUSTER_EVENTS,
+    PayloadType.REGISTER_CLUSTER: BudServeWorkflowStepEventName.CREATE_CLUSTER_EVENTS,
+    PayloadType.PERFORM_MODEL_EXTRACTION: BudServeWorkflowStepEventName.MODEL_EXTRACTION_EVENTS,
+    PayloadType.PERFORM_MODEL_SECURITY_SCAN: BudServeWorkflowStepEventName.MODEL_SECURITY_SCAN_EVENTS,
+    PayloadType.DELETE_CLUSTER: BudServeWorkflowStepEventName.DELETE_CLUSTER_EVENTS,
+    PayloadType.DELETE_DEPLOYMENT: BudServeWorkflowStepEventName.DELETE_ENDPOINT_EVENTS,
+    PayloadType.DELETE_WORKER: BudServeWorkflowStepEventName.DELETE_WORKER_EVENTS,
+    PayloadType.ADD_WORKER: BudServeWorkflowStepEventName.BUDSERVE_CLUSTER_EVENTS,
+    PayloadType.FETCH_LICENSE_FAQS: BudServeWorkflowStepEventName.LICENSE_FAQ_EVENTS,
+    PayloadType.DEPLOY_QUANTIZATION: BudServeWorkflowStepEventName.QUANTIZATION_DEPLOYMENT_EVENTS,
+    PayloadType.RUN_BENCHMARK: BudServeWorkflowStepEventName.BUDSERVE_CLUSTER_EVENTS,
+    PayloadType.ADD_ADAPTER: BudServeWorkflowStepEventName.ADAPTER_DEPLOYMENT_EVENTS,
+    PayloadType.DELETE_ADAPTER: BudServeWorkflowStepEventName.ADAPTER_DELETE_EVENTS,
+}
+
+
 class ClusterStatusEnum(StrEnum):
     """Cluster status types.
 


### PR DESCRIPTION
### Title: Enhancement: Update ETA Events in Workflow and Step Tables

#### Linked Issues

- Closes https://github.com/BudEcosystem/bud-serve/issues/2595

#### Description

This PR updates ETA-related events to be recorded in the `progress` column of the workflow table and the `data` column of the workflow step table to improve tracking and visibility.

#### Methodology/Tasks Implemented

- Updated logic to log ETA progress in the workflow `progress` column.
- Enhanced workflow step logging by recording ETA events in the `data` column.

#### Testing

- Verified that ETA updates correctly reflect in both workflow and step tables.
- Validated updates with simulated ETA event streams.

#### Estimated Time

- Approximately 2 hours.

#### Screenshots/Logs

Workflow table
<img width="604" alt="image" src="https://github.com/user-attachments/assets/f5e8b40a-21cb-4d74-8a98-3dc32ca8f1bf" />

Workflow step table
<img width="604" alt="image" src="https://github.com/user-attachments/assets/af13bad2-53fd-40ac-ad7a-0b43e1feb218" />

#### Additional Notes

- Improves observability and traceability of long-running workflows.