### PR TITLE
fix: model onboard via huggingface license issue

### DIFF
--- a/budapp/model_ops/services.py
+++ b/budapp/model_ops/services.py
@@ -1404,6 +1404,7 @@ class LocalModelWorkflowService(SessionMixin):
             license_type=license_type,
             description=license_description,
             suitability=license_suitability,
+            data_type=ModelLicenseObjectTypeEnum.MINIO,
         )
         return await ModelLicensesDataManager(self.session).insert_one(
             ModelLicenses(**license_data.model_dump(exclude_none=True))


### PR DESCRIPTION
### Title: BugFix: Incorrect Model License Data Type Sent to Frontend (HuggingFace License Not Viewable)

#### Linked Issues

- Closes https://github.com/BudEcosystem/bud-serve/issues/2703

#### Description

This PR resolves an issue where HuggingFace model licenses were not viewable on the frontend due to an incorrect `data_type` being sent from the backend. Ensures the correct license data type is passed for proper rendering.

#### Methodology/Tasks Implemented

- Fixed logic to correctly assign the `data_type` for HuggingFace model licenses.
- Validated that the frontend receives and displays license information correctly.

#### Testing

- Verified license visibility for HuggingFace models in the frontend.
- Confirmed correct data is returned from the license retrieval API.

#### Estimated Time

- Approximately 1 hour.

#### Screenshots/Logs

<img width="1427" alt="image" src="https://github.com/user-attachments/assets/663ce34a-4d31-4ab6-a152-70b690d2659b" />

#### Additional Notes

- This bug was blocking users from viewing HuggingFace model license details.