### PR TITLE
fix: avoid duplicate benchmark name

### DIFF
--- a/budapp/benchmark_ops/services.py
+++ b/budapp/benchmark_ops/services.py
@@ -95,6 +95,15 @@ class BenchmarkService(SessionMixin):
             {"workflow_id": db_workflow.id}
         )
 
+        # Check duplicate benchmark name
+        if request.name:
+            with BenchmarkCRUD() as crud:
+                db_benchmark = crud.fetch_one(
+                    conditions={"name": request.name, "user_id": current_user_id},
+                )
+                if db_benchmark:
+                    raise ClientException("Benchmark name already exists")
+
         # Validate resources
         if model_id:
             db_model = await ModelDataManager(self.session).retrieve_by_fields(


### PR DESCRIPTION
### Title: BugFix: Raise Error for Duplicate Benchmark Name

#### Linked Issues

- Closes https://github.com/BudEcosystem/bud-serve/issues/2467

#### Description

This PR addresses an issue where duplicate benchmark names could be created without validation. The fix ensures that a clear error is raised when attempting to create a benchmark with a name that already exists.

#### Methodology/Tasks Implemented

- Added validation logic to check for existing benchmark names before creation.
- Raised appropriate error message when a duplicate name is detected.

#### Testing

- Verified benchmark creation fails with a meaningful error message on duplicate name input.
- Successfully created benchmarks with unique names.

#### Estimated Time

- Approximately 1 hour.

#### Screenshots/Logs

<img width="948" alt="image" src="https://github.com/user-attachments/assets/bcb39f5d-aaf9-4209-ac1d-f98620e5f321" />

#### Additional Notes

- This fix improves data integrity and prevents conflicts in benchmark naming.