### PR TITLE
Fix cloud model namespace format for proxy cache

### DIFF
--- a/budapp/model_ops/services.py
+++ b/budapp/model_ops/services.py
@@ -3696,7 +3696,10 @@ class ModelService(SessionMixin):
 
         # Generate namespace and deployment URL
         # Use model.uri as namespace for cloud models
+        # Remove provider prefix if present (e.g., "openai/gpt-4" -> "gpt-4")
         namespace = db_model.uri
+        if "/" in namespace:
+            namespace = namespace.split("/", 1)[1]
 
         # Use the proxy service URL for cloud models
         deployment_url = "budproxy-service.svc.cluster.local"


### PR DESCRIPTION
## Summary
- Fixed cloud model namespace to use only model name (e.g., "gpt-4") instead of full URI format (e.g., "openai/gpt-4")
- The proxy cache expects only the model name without the provider prefix

## Test plan
- [ ] Deploy a cloud model (e.g., OpenAI GPT-4)
- [ ] Verify the model name in proxy cache is "gpt-4" not "openai/gpt-4"
- [ ] Test that the cloud model endpoint works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)